### PR TITLE
SIMP-348 Updated to work around :ref: bug

### DIFF
--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -20,6 +20,13 @@ BuildRequires: python27
 %endif
 BuildRequires: python-pip
 BuildRequires: python-virtualenv
+BuildRequires: fontconfig
+BuildRequires: dejavu-sans-fonts
+BuildRequires: dejavu-sans-mono-fonts
+BuildRequires: dejavu-serif-fonts
+BuildRequires: dejavu-fonts-common
+BuildRequires: libjpeg-devel
+BuildRequires: zlib-devel
 
 %description
 Documentation for SIMP %{version}-%{release}
@@ -45,16 +52,28 @@ virtualenv venv
 source venv/bin/activate
 pip install --upgrade sphinx
 pip install --upgrade rst2pdf
+pip install --upgrade pillow
+pip install --upgrade svglib
 
 sphinx-build -E -n -t simp_%{simp_major_version} -b html       -d sphinx_cache docs html
 sphinx-build -E -n -t simp_%{simp_major_version} -b singlehtml -d sphinx_cache docs html-single
+
+# Rst2pdf is currently broken on references so we have to remove them.
+# This should be removed when this bug is fixed.
+find docs -name "*.rst" -exec sed -i 's/:ref://g' {} \;
+
 sphinx-build -E -n -t simp_%{simp_major_version} -b pdf        -d sphinx_cache docs pdf
+
+if [ ! -s pdf/SIMP_Documentation.pdf ]; then
+  echo "ERROR: Could not generate PDF"
+  exit 1
+else
+  mv pdf/SIMP_Documentation.pdf pdf/SIMP-%{version}-%{release}.pdf
+fi
 
 if [ ! -d changelogs ]; then
   mkdir changelogs
 fi
-
-mv pdf/SIMP_Documentation.pdf pdf/SIMP-%{version}-%{release}.pdf
 
 %install
 # Just the Docs...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,16 @@
+Babel==2.0
+Jinja2==2.8
+MarkupSafe==0.23
+Pillow==2.9.0
+Pygments==2.0.2
 Sphinx==1.3.1
+alabaster==0.7.6
+docutils==0.12
+pdfrw==0.2
+pytz==2015.4
+reportlab==3.2.0
+rst2pdf==0.93
+six==1.9.0
+snowballstemmer==1.2.0
+sphinx-rtd-theme==0.1.8
+svglib==0.6.3


### PR DESCRIPTION
The current version of rst2pdf has an issue with generating PDFs with
:ref: tags.

This fixes that for the RPM version and updates the requirements file
for RTD.

SIMP-348 #comment Fixed for 4.2.X

Change-Id: I37cb20c9edefacf0971d72245ca3b2f041f25ab3