### PR TITLE
SIMP-348 Fix for :ref: issue with rst2pdf

### DIFF
--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -20,6 +20,13 @@ BuildRequires: python27
 %endif
 BuildRequires: python-pip
 BuildRequires: python-virtualenv
+BuildRequires: fontconfig
+BuildRequires: dejavu-sans-fonts
+BuildRequires: dejavu-sans-mono-fonts
+BuildRequires: dejavu-serif-fonts
+BuildRequires: dejavu-fonts-common
+BuildRequires: libjpeg-devel
+BuildRequires: zlib-devel
 
 %description
 Documentation for SIMP %{version}-%{release}
@@ -45,9 +52,16 @@ virtualenv venv
 source venv/bin/activate
 pip install --upgrade sphinx
 pip install --upgrade rst2pdf
+pip install --upgrade pillow
+pip install --upgrade svglib
 
 sphinx-build -E -n -t simp_%{simp_major_version} -b html       -d sphinx_cache docs html
 sphinx-build -E -n -t simp_%{simp_major_version} -b singlehtml -d sphinx_cache docs html-single
+
+# Rst2pdf is currently broken on references so we have to remove them.
+# This should be removed when this bug is fixed.
+find docs -name "*.rst" -exec sed -i 's/:ref://g' {} \;
+
 sphinx-build -E -n -t simp_%{simp_major_version} -b pdf        -d sphinx_cache docs pdf
 
 if [ ! -d changelogs ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,16 @@
+Babel==2.0
+Jinja2==2.8
+MarkupSafe==0.23
+Pillow==2.9.0
+Pygments==2.0.2
 Sphinx==1.3.1
+alabaster==0.7.6
+docutils==0.12
+pdfrw==0.2
+pytz==2015.4
+reportlab==3.2.0
+rst2pdf==0.93
+six==1.9.0
+snowballstemmer==1.2.0
+sphinx-rtd-theme==0.1.8
+svglib==0.6.3


### PR DESCRIPTION
This is a workaround for the current issue with ref2pdf where a PDF is
not generated if there are :ref: tags in your code.

In this case, the :ref: tags are stripped from the RST files prior to
generating the PDF.

This should be corrected when the bug is fixed.

This also fixes the issue with RTD failing.

SIMP-348 #close #comment 5.1.X Fix