### PR TITLE
(SIMP-323) Documentation updates

### DIFF
--- a/docs/common/Client_Management.rst
+++ b/docs/common/Client_Management.rst
@@ -22,18 +22,6 @@ Configuring the Puppet Master
 
 Perform the following actions as ``root`` on the Puppet Master system prior to attempting to install a client.
 
-Configure DHCP
---------------
-
-1. Log on as *root*.
-2. Open the ``/srv/rsync/dhcpd/dhcpd.conf`` file and edit it to suit the necessary environment.
-
-    .. note:: Enter the hardware ethernet and fixed-address for each client that will be kickstarted. An example ``dhcpd.conf`` is listed in the Appendix, where ``192.168.1.100`` is the client targeted for PXE/provisioning. Be sure to substitute in the actual values appropriate to your environment, including the ethernet address of the target client.
-
-3. Save and close the file.
-4. Type ``puppet agent -t --tags dhcpd`` on the Puppet Master to apply the changes.
-
-
 Configure DNS
 -------------
 
@@ -44,74 +32,72 @@ are noted in this section.
 It is possible to use an existing DNS setup; however, the following
 table lists the steps for a local setup.
 
-1. Type ``cd /srv/rsync/bind_dns``
+.. only:: simp_4
+   
+ 1. Type ``cd /srv/rsync/bind_dns``
+
+.. only:: not simp_4
+
+ 1. Type ``cd /var/simp/rsync/OSTYPE/MAJORRELEASE/bind_dns``
+
 2. Modify the named files to correctly reflect the environment. At a minimum, the following files under ``/srv/rsync/bind_dns/default`` should be edited:
 
-  a. ``named/etc/named.conf``
-  b. ``named/etc/zones/your.domain``
-  c. ``named/var/named/forward/your.domain.db``
-  d. ``named/var/named/reverse/0.0.10.db``
+  A. ``named/etc/named.conf``
+  B. ``named/etc/zones/your.domain``
+  C. ``named/var/named/forward/your.domain.db``
+  D. ``named/var/named/reverse/0.0.10.db``
 
-  .. note:: For the ``named/var/named/forward/your.domain.db`` and ``named/var/named/reverse/0.0.10.db`` files, add clients as needed. Make sure to rename both of these files to more appropriately match your system configuration.
+.. important:: For the ``named/var/named/forward/your.domain.db`` and ``named/var/named/reverse/0.0.10.db`` files, add clients as needed. Make sure to rename both of these files to more appropriately match your system configuration.
 
 3. At a minimum, review ``named/etc/named.conf`` and check/update the following:
 
-  a. Update the IP for allow-query and allow-recursion
-  b. Delete any unnecessary zone stanzas (i.e. forwarding) if not necessary
-  c. Substitute in the FQDN of your domain for all occurrences of your.domain
+  A. Update the IP for allow-query and allow-recursion
+  B. Delete any unnecessary zone stanzas (i.e. forwarding) if not necessary
+  C. Substitute in the FQDN of your domain for all occurrences of your.domain
 
 4. Type ``puppet agent -t --tags named`` on the Puppet Master to apply the changes. Validate DNS and ensure the ``/etc/resolv.conf`` is updated appropriately
 5. If an error about the rndc.key appears when starting bind, copy the ``rndc.key`` to ``/etc`` then re-run the puppet command: ``cp -p /var/named/chroot/etc/rndc.key /etc/rndc.key``
 
 Table: DNS Configuration Procedure
 
-Configure the Kickstart
------------------------
+Configure DHCP
+--------------
 
-1. Locate the following files in the ``/var/www/ks`` directory:
+Log on as *root*.
 
-  a. ``pupclient_x86_64.cfg``
-  b. ``puppet_x86_64.cfg``
-  c. ``diskdetect.sh``
+.. only:: simp_4
 
-2. Open the applicable files and follow the instructions provided within them to replace the variables.
+ Open the ``/srv/rsync/dhcpd/dhcpd.conf`` file and edit it to suit the necessary environment.
 
-  .. note:: The files that need to be edited vary based on the information entered in the Manifest section. Type ``sed -i ‘s/#KSSERVER#/***<Server IP Address>***/g’ *.cfg`` to set the IP address of the kickstart server.
+.. only:: not simp_4
 
-  .. note:: Use the following command to obtain a hashed value of the passwords that will be changed ``ruby -r 'digest/sha2' -e 'puts "password".crypt("$6$" + rand(36**8).to_s(36))'``
+ Open the ``/var/simp/rsync/OSTYPE/MAJORRELEASE/dhcpd/dhcpd.conf`` file and edit it to suit the necessary environment.
 
-3. Type ``chown root.apache /srv/www/ks/*`` to ensure that all files are owned by ``root`` and in the ``apache`` group.
-4. Type ``chmod 640 /srv/www/ks/*`` to change the permissions so the owner can read and write the file and the ``apache`` group can only read. Once this is complete, the system is ready to kickstart the clients.
+An example ``dhcpd.conf`` is listed in the appendix.  This can be used as a baseline. Make sure the following is done :
 
-Table: Kickstart Configuration Procedure
+  A. The ``next-server`` setting in the pxeclients class block points to the IP Address of the TFTP server.
+  B. Create a Subnet block (example of ``192.168.122.0`` in Appendix)  and edit the following:
 
-The ``diskdetect.sh`` script is responsible for detecting the first active disk and applying a disk configuration. Edit this file to meet any necessary requirements or use this file as a starting point for further work.
+    -    Make sure the **router** and **netmask** are correct for your environment.
+    -    Enter the hardware ethernet and fixed-address for each client that will be kickstarted. (example ``192.168.122.16`` in Appendix.) SIMP does not allow clients to pick random IP Address in a subnet.  The MAC address must be associated with and IP Address here. (You can add additional ones as needed.)
+    -    Enter the domain name for option **domain-name** 
+    -    Enter the IP Address of the DNS server for option **domain-name-servers**
+
+Save and close the file.
+Type ``puppet agent -t --tags dhcpd`` on the Puppet Master to apply the changes.
+
+.. include:: ../common/PXE_Boot.rst
 
 Setting Up the Client
 ---------------------
 
-The table below lists the steps to PXE boot the system and set up the client.
+The following lists the steps to PXE boot the system and set up the client.
 
-1. Power up the system and navigate to the **Other Options** menu.
-2. Select the **BIOS Setup option**.
-3. Select **Enable Onboard NIC**.
-4. Select **Enabled with PXE**.
-
-  .. note:: If a virtualization option is available, select that as well.
-
-5. Save the new settings and close.
-
-  .. note:: The system restarts.
-
-6. As the system powers up again, navigate to the **Other Options** menu.
-7. Select **Onboard NIC**.
-
-  .. note:: The PXE boot of the system occurs and CentOS or RHEL is installed.
-
-8. Puppet will not autosign domains by default and waitforcert is enabled. The client will check in every 30 seconds for a signed cert.
-9. Once the client installs, reboots, and begins to bootstrap, it will check in for the first time. You will be required to run ``puppet cert sign puppet.client.fqdn``.
-
-Table: PXE Boot Procedure
+1. Set up your client's bios or virtual settings to boot off the network.
+2. Make sure the MAC address of the client is set up in DHCP (see Setting Up DHCP for more info.) 
+3. Restart the system.
+4. Once the client installs, reboots, and begins to bootstrap, it will check in for the first time.
+5. Puppet will not autosign puppet certificates by default and waitforcert is enabled. The client will check in every 30 seconds for a signed cert. Log on to the puppet server and run ``puppet cert sign puppet.client.fqdn``.
 
 Upon successful deployment of a new CentOS or RHEL client, it is highly recommended that LDAP administrative accounts be created. See Chapter 2 of the SIMP Users Guide for user management.
 
@@ -134,7 +120,7 @@ The table below lists the steps to determine which certificates are working and 
 1. Type ``cd /etc/puppet/environments/simp/keydist``
 2. Type ``find . -name “****<Your.Domain>*.pub” -exec openssl verify -CApath cacerts {} \;``
 
-  .. note::
+.. important::
 
     The screen displays ``./<Host Name>.<Your.Domain>/<Host Name>.<Your.Domain>.pub: OK``
     If anything other than OK appears for each host, analyze the error and ensure that the CA certificates are correct.

--- a/docs/common/PXE_Boot.rst
+++ b/docs/common/PXE_Boot.rst
@@ -1,101 +1,108 @@
-Configure the PXE Boot
-======================
+Configure PXE Boot 
+------------------
 
-In order to :term:`Preboot Execution Environment` (PXE) boot clients, a copy of the ISOs for all versions of RHEL
-being kickstarted is required.
+Sample kickstart templates have been provided in the ``/var/www/ks`` directory on the SIMP server  and on the SIMP DVD under ``/ks``.  Pre-boot images are locate in the DVD under ``/images/pxeboot``.  If you have an existing :term:`Preboot Execution Environment` (PXE) setup you can use these to PXE a SIMP client. Follow your own sites procedures for this.    
 
-Setting Up the Kickstart
-------------------------
+In this section we describe how to configure the Kickstart and TFTP servers to PXE boot a SIMP client.  (The DHCP server setup, also required for PXE booting, is discussed in and earlier chapter.)    
 
-The system follows the standard kickstart model. Kickstart files are
-placed in the ``/srv/www/ks`` directory. Custom packages are placed in an
-appropriate repository created under the ``/srv/www/yum`` directory.
+.. note:: This example sets up a PXE boot for a system that is the same OS as the SIMP Server. If you are setting up a PXE boot for a different OS then you must make sure that the OS packages are available for all systems you are trying to PXE boot through YUM. There are notes through out the instructions to help in setting multiple OS but they are not comprehensive.  You should understand DHCP, KS, YUM and TFTP relationships for PXE booting before attempting this.
 
-Once the model is ready, the default SIMP settings provide access to the
-user's trusted subnets as defined in the
-``/etc/puppet/environments/simp/hieradata/simp_def.yaml`` directory.
 
-The ``pupclient_x86_64.cfg`` file in the ``/var/www/ks`` directory is
-used as an example in the following sections.
+Setting Up Kickstart
+~~~~~~~~~~~~~~~~~~~~
+This section describes how to configure the kickstart server.  
+   
+1. Locate the following files in the ``/var/www/ks`` directory:
+    A.  ``pupclient_x86_64.cfg``
+    B.  ``diskdetect.sh``
+2. Open each of the files and follow the instructions provided within them to replace the variables. You need to know the IP Addresses of the YUM, Kickstart, and TFTPserver. (They default to the simp server in simp config).  
+    A. ``pupclient_x86_64.cfg``:   
+        1.) Note: #KSSERVER# should be replaced with Kickstart Server IP not Yum IP.  (They are the same if you used the defaults.)
+        2.) In the URL line use the YUMSERVER ip not the Kickstart server IP. (Although on a default SIMP system the YUM and kicktart server are the same server so it is not a problem.)
+        3.) Use the commands in the top of the file in the comments section to generate the password hashes.  
+    B. ``diskdetect.sh``:  The ``diskdetect.sh`` script is responsible for detecting the first active disk and applying a disk configuration. Edit this file to meet any necessary requirements or use this file as a starting point for further work. It will work as is for most systems as long as your disk device names are in the list.
+3. Type ``chown root.apache /var/www/ks/*`` to ensure that all files are owned by ``root`` and in the ``apache`` group.
+4. Type ``chmod 640 /var/www/ks/*`` to change the permissions so the owner can read and write the file and the ``apache`` group can only read. 
 
-.. note::
+.. note:: The URLs and locations in the file are setup for a default SIMP install. That means the same OS and version as the SIMP server, all servers in one location (on the SIMP server) and in specific directories. If you have installed these servers in a different location then the defaults, you may need to edit URLs or directories.
 
-    Sample kickstart templates have been provided in the ``/srv/www/ks`` directory
-    on the SIMP DVD at the ``root`` level.
+.. note:: If you want to PXE boot more than this operating system, make a copy of these files, name them appropriately and update URLS and links inside and anything else you may need. (You must know what you are doing before attempting this.) If you are booting more than one OS you must also make sure your YUM server has the OS packages for the other OSs. By default the YUM server on SIMP has the packages only for the version of OS installed on the SIMP server.
+
 
 Setting up TFTP
----------------
+~~~~~~~~~~~~~~~
 
 This section describes the process of setting up static files and
 manifests for TFTP.
 
 Static Files
-~~~~~~~~~~~~
+____________
 
-Type ``cd /srv/rsync/tftpboot`` and
-then type ``ls`` to check for the existence of the
-``/srv/rsync/tftpboot/linux-install/rhel<Version>-<Architecture>``
-directory.
+Verify the static files are in the correct location:
 
-If the directory does not exist, create one in that location and add the
-``vmlinuz`` and ``initrd.img`` files from the ``images/pxeboot`` directory of
-the SIMP DVD. An example is provided below for setting up the CentOS
-RHEL\_MAJOR\_MINOR\_VERSION distribution.
+.. only:: simp_4
 
-.. code-block:: bash
+ Type ``cd /srv/rsync/tftpboot`` and
+ then type ``ls`` to check for the existence of the
+ ``/srv/rsync/tftpboot/linux-install/OSTYPE-MAJORRELEASE_ARCH``
+ directory.
 
-  cd /srv/rsync/tftpboot/linux-install
+.. only:: not simp_4
 
-  mkdir centosRHEL_MAJOR_MINOR_VERSION_x86_64
-  cd centosRHEL_MAJOR_MINOR_VERSION_x86_64
+ Type ``cd /var/simp/rsync/OSTYPE/MAJORRELEASE/tftpboot`` and
+ then type ``ls`` to check for the existence of the
+ ``linux-install/OSTYPE-MAJORRELEASE_ARCH``
+ directory.
 
-  cp -p
-   /var/www/yum/CentOS/RHEL_MAJOR_MINOR_VERSION/x86_64/images/pxeboot/* .
+ OSTYPE and MAJORRELEASE under rsync are the version of the SIMP server
 
-  cd ..
+where OSTYPE and MAJORRELEASE under linux-install are the OS type and OS major version of the systems you will be PXE booting.
+ 
+Under this directory your should find a directory named OSTYPE-MAJORRELEASE.MINORRELEASE-ARCH and a link to this directory named OSTYPE-MAJORRELEASE-ARCH.
 
-  chmod 640 centosRHEL_MAJOR_MINOR_VERSION_x86_64
-  chown root:nobody centosRHEL_MAJOR_MINOR_VERSION_x86_64
+Under OSTYPE-MAJORRELEASE.MINORRELEASE-ARCH your should find the files:
 
-  unlink centosRHEL_MAJOR_VERSION_x86_64
+- initrd.img
+- vmlinuz
 
-  ln -s centosRHEL_MAJOR_MINOR_VERSION_x86_64
-   centosRHEL_MAJOR_VERSION_x86_64
+If these are not there then you must create the directories as needed and copy the files from 
+``/var/www/yum/OSTYPE/MAJORRELEASE/ARCH/images/pxeboot`` or from the images directory on the SIMP DVD.
+
+
+.. important:: The link is what is used in the TFTP configuration files.
+
+.. note:: If you want to be able to PXE boot different OS, then add a directory for each on and obtain the pxeboot images and copy them under the linux-install directory. SIMP only provides images for the OS for the SIMP server.
 
 Manifest
-~~~~~~~~
+________
 
-Assuming that the Puppet server is being used, create and add the
-following example code to a site manifest,
-``/etc/puppet/environment/simp/modules/site/manifests/tftpboot.pp``. Keep in mind that the
-code varies based on the model being kickstarted.
+Create a site manifest for the TFTP server on the Puppet server.  
 
-Source Code for Setting Up TFTP on Puppet Server
-TFTP Examples
+1. Create the file ``/etc/puppet/environment/simp/modules/site/manifests/tftpboot.pp``.  Use the source code example below. 
+     A. Replace KSSERVER with the IP address of Kickstart server (or the code to look up the IP Address using Hiera).
+     B. Replace OSTYPE, MAJORRELEASE and ARCH with the correct value for the systems you will be PXE booting.
+     C. MODEL NAME is usually of the form OSTYPE-MAJORRELEASE-ARCH for consistency.
 
 .. code-block:: ruby
 
-  # Set KSSERVER statically or use Hiera for lookup
   class site::tftpboot {
     include 'tftpboot'
 
-    tftpboot::linux_model { 'CentOS_RHEL_MAJOR_VERSION':
-      kernel => 'centosRHEL_MAJOR_VERSION_x86_64/vmlinuz',
-      initrd => 'centosRHEL_MAJOR_VERSION_x86_64/initrd.img',
+    tftpboot::linux_model { 'MODEL NAME':
+      kernel => 'OSTYPE-MAJORRELEASE-ARCH/vmlinuz',
+      initrd => 'OSTYPE-MAJORRELEASE-ARCH/initrd.img',
       ks     => "http://KSSERVER/ks/pupclient_x86_64.cfg",
       extra  => "ksdevice=bootif\nipappend 2"
     }
 
-    tftpboot::assign_host { 'default': model => 'CentOS_RHEL_MAJOR_VERSION' }
+    tftpboot::assign_host { 'default': model => 'MODEL NAME' }
   }
 
-Next, add the tftpboot site manifest to your puppet server node via
-Hiera. If it does not already exist, create
-``/etc/puppet/environments/simp/hieradata/hosts/your.server.fqdn.yaml``. Add the following
-example code to that yaml file.
+2. Add the tftpboot site manifest on your puppet server node via Hiera.
 
-Source Adding TFTP Site Manifest to Hiera
-TFTP Examples
+Create the file (or edit if it exists):  ``/etc/puppet/environments/simp/hieradata/hosts/<tftp.server.fqdn>.yaml``.
+(By default the TFTP server is the same as your puppet server o in the deault case it will exist.)
+Add the following example code to that yaml file.
 
 .. code-block:: yaml
 
@@ -103,6 +110,7 @@ TFTP Examples
   classes:
     - 'site::tftpboot'
 
-
-After updating the above file, type ``puppet agent -t --tags tftpboot``
+3. After updating the above file, type ``puppet agent -t --tags tftpboot``
 on the Puppet server.
+
+.. note:: To PXE boot more OSs create, in the tftpboot.pp file, a tftpboot::linux_model block for each OS type using the extra directories and kickstart files created using the notes in previous sections. Point individual systems to them by adding assign_host lines with their MAC pointing to the appropriate model name.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
-    'rst2pdf.pdfbuilder',
+#    'rst2pdf.pdfbuilder',
 #    'sphinxcontrib.fulltoc',
 ]
 

--- a/docs/installation_guide/AppendixB.rst
+++ b/docs/installation_guide/AppendixB.rst
@@ -1,0 +1,171 @@
+Appendix B
+==========
+
+This sections provides a list of variables that are configurable during the install.
+
+.. _List of Installation Variables:
+
+List of Installation Variables
+------------------------------
+
++-------------------------------------------+------------------+-------------------+-----------------+
+|Description                                |  Default Setting | Puppet Variable   | Section         |
++===========================================+==================+===================+=================+
+| Enable FIPS-140-2 compliance              | enabled          |  use_fips         | FIPS            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Do you want to set up network interface   |                  | none -            | SYSTEM          |
+| - use DHCP or Static for NIC              | static           | The device is     |                 |  
+| - Hostname of server                      | puppet.change.me | confgured         |                 |
+| - IP Address of server                    | none             | none              |                 |
+| - Netmask                                 | none             | none              |                 | 
+| - Default gateway                         | none             | none              |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Your DNS server                           | IP this install  | dns::servers      |  DNS            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The search domain for DNS.                | change.me        | dns::search       |  DNS            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Subnet used for clients managed by the    | subnet of IP     | client_nets       |  PUPPET         |
+| puppet server                             | this install     |                   |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| NTP servers.                              | none             | ntpd::servers     |  NTP            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| IP addr of primary log server (rsyslog)   | none             | log_servers       |  RSYSLOG        |
++-------------------------------------------+------------------+-------------------+-----------------+
+| IP address of failover log server.        | none             | failover_log\     | RSYSLOG         |  
+|                                           |                  | _server           |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Yum server for simp modules.              | IP this install  | simp::yum\        | YUM             |
+|                                           |                  | ::servers         |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Turn on the audit deamon?                 | true             | use_auditd        | SYSTEM          |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Turn on iptable deamon?                   | true             | use_iptables      | SYSTEM          |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The default system run level              | 3                | common::runlevel  | SYSTEM          |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Do you want to set SELINUX to enforcing?  | true             | selinux::ensure   |  SYSTEM         |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Set a grub password on the puppet server? | true             | set_grub_password |   GRUB          |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Make puppet server the master yum server? | true             | is_master_yum\    | YUM             | 
+|                                           |                  | _server           |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The FQDN of the puppet server.            | puppet.change.me | puppet::server    | PUPPET          |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Puppet servers IP address.                | current IP       | puppet::server\   | PUPPET          |
+|                                           |                  | ::ip              |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| FQDN of Puppet Certificate Authority (CA) | puppet server    | puppet::ca        | PUPPET          |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The port Puppet CA will listen on.        | 8141             | puppet::ca_port   | PUPPET          |  
++-------------------------------------------+------------------+-------------------+-----------------+
+| The DNS name of puppet database server.   | puppet server    | puppetdb::master\ | PUPPET          |
+|                                           |                  | ::config\         |                 |
+|                                           |                  | ::puppetdb_server |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The port used by the puppet database      | 8139             | puppetdb::master\ | PUPPET          |
+| server                                    |                  | ::config\         |                 |
+|                                           |                  | ::puppetdb_port   |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Do you want to use LDAP?                  |  true            | use_ldap          | PUPPET          |
++-------------------------------------------+------------------+-------------------+-----------------+
+| LDAP Server Base Distinquish Name (DN)    | generate from    |                   | LDAP            |
+|                                           | puppetsrv name   | ldap::basedn      |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The LDAP Bind Distiquished name.          | generate from    |                   | LDAP            |
+|                                           | LDAP base DN     | ldap::bind_dn     |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| LDAP Bind password                        | yes              | ldap::bind_hash   | LDAP            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| LDAP Sync Distiquished name.              | generate from    |                   | LDAP            |
+|                                           | LDAP base DN     | ldap::sync_dn     |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| LDAP Sync password                        | yes              | ldap::sync_pw     | LDAP            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The LDAP root DN.                         | generated from   |                   |                 |
+|                                           | the ldap::basedn | ldap::root_dn     | LDAP            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| LDAP root password                        |  no              | ldap::root_hash   | LDAP            |
+| This password is used for manually        |                  |                   |                 |
+| updating LDAP, you will want to set it    |                  |                   |                 |
+| your self.                                |                  |                   |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The URI for your LDAP server.             | ldap:://         |                   |                 |
+|                                           | <puppetsrvFQDN>  | ldap::master      | LDAP            |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The directory that will hold files used   | /var/simp/rsync/ |                   | RSYNC           |
+| to sync oprational directories            | OSTYPE/MJRREL    |                   |                 |
++-------------------------------------------+------------------+-------------------+-----------------+
+| The server that remote syncs              | 127.0.0.1        |  rsync::server    | RSYNC           |
++-------------------------------------------+------------------+-------------------+-----------------+
+| Maximum rsync timeout in seconds          | 1                |  rsync::timeout   | RSYNC           |
++-------------------------------------------+------------------+-------------------+-----------------+
+
+Table: Sample values for SIMP install
+
+
+Configuration
+-------------
+
+This briefly describes what is being configured in the different sections indicated in the table above. 
+
+If you make changes to the default settings these are usually set in
+
+.. only:: not simp_4
+
+  -  ``/etc/puppet/environments/simp/hieradata/simp_def.yaml``
+
+.. only:: simp_4
+
+  -  ``/etc/puppet/hieradata/simp_def.yaml``
+
+or one of the other yaml files in the hieradata directory.
+
+These Hiera files can be used after initial set up to change settings.  The :ref:`Hiera` section gives an introduction to SIMPS use of Hiera.
+
+FIPS
+
+- Turning on and off FIPS mode sets kernel parameters and systems environment variables to ensure the system is FIPS-140-2 compliant. This has compatability issues and you should understand FIPS if you are turning this on.
+- This can be reset after installation without rebuilding.
+
+GRUB
+
+-  Grub password in ``/boot/grub/grub.conf``
+
+DNS
+
+- The /etc/resolv.conf
+- The DNS server is not set up by this.  There are instructions for that.
+
+SYSTEM
+
+-  Basic network setup under /etc/sysconfig. Puppet does not control network card settings and these can be changed through system utilities.
+-  Start up files in /etc/init.d
+-  Configuration files under /etc
+-  Rsyslog settings for the server and clients.
+
+PUPPET
+
+-  Autosigning in ``*/etc/puppet/autosign.conf``
+-  Fileserving in ``*/etc/puppet/fileserver.conf``
+-  Puppet server and Certificate Authority (CA) information in ``/etc/puppet/puppet.conf``
+-  Server certificates for the puppet server itself (Fake CA)
+-  There are instructions for installing Official PKI certificates after initial configuration.
+
+LDAP
+
+- if you select use_ldap and set this server as LDAP, open ldap is configured on this server and puppet is configured to point clients to this server for authentication.
+- if you select use_ldap and point to another server /etc/slapd files are configured to point you to the LDAP server and puppet is set up to point any clients to that server.
+- if you select not to use LDAP the system is set up to use local authenticaton.
+
+RSYNC
+
+- The puppet server is configured to rsync data directories for services like DNS, DHCP or TFTP.   
+
+
+YUM
+
+-  Base YUM repositories 
+
+
+

--- a/docs/installation_guide/Hiera_Overview.rst
+++ b/docs/installation_guide/Hiera_Overview.rst
@@ -1,3 +1,6 @@
+
+.. _Hiera:
+
 Hiera Overview
 ==============
 

--- a/docs/installation_guide/PXE_Boot.rst
+++ b/docs/installation_guide/PXE_Boot.rst
@@ -1,1 +1,0 @@
-.. include:: ../common/PXE_Boot.rst

--- a/docs/installation_guide/SIMP_Server_Installation.rst
+++ b/docs/installation_guide/SIMP_Server_Installation.rst
@@ -34,30 +34,6 @@ repeatable.
     regarding certificate validation appear, check the Puppet server and
     client times to ensure they are synchronized.
 
-Using the configuration script, the following items are configured:
-
-.. note::
-
-  This needs updated for the new puppetserver settings
-  which includes Puppet Environments
-
--  Grub password in ``/boot/grub/grub.conf``
--  Basic network setup
--  Autosigning in ``*/etc/puppet/autosign.conf``
--  Fileserving in ``*/etc/puppet/fileserver.conf``
--  Puppet server and Certificate Authority (CA) information in ``/etc/puppet/puppet.conf``
-
-.. only:: not simp_4
-
-  -  ``/etc/puppet/environments/simp/hieradata/simp_def.yaml``
-
-.. only:: simp_4
-
-  -  ``/etc/puppet/hieradata/simp_def.yaml``
-
--  Server certificates for the puppet server itself (Fake CA)
--  Base YUM repositories
-
 ..  warning::
     Keep in mind as the installation process begins that Puppet does not
     work well with capital letters in host names. Therefore, they should
@@ -77,12 +53,6 @@ server.
 
 Table: SIMP Default Passwords
 
-Below is a table containing sample variables and their corresponding
-values that apply to this SIMP deployment. These variables and values
-will be helpful in illustrating how configuration files are set up. Your
-values will obviously differ, depending on your installation
-environment.
-
 ========= ========
 Utility   Password
 ========= ========
@@ -91,25 +61,8 @@ Root User Plea$e Ch@nge Th1s Immediately!
 Simp User CorrectHorseBatteryStaple
 ========= ========
 
-==================== =====
-Variable name        Value
-==================== =====
-Domain name          simp.net
-Fully qualified name puppet.simp.net
-IP address           192.168.1.10
-Gateway              192.168.1.1
-DNS server           192.168.1.10
-DNS search entry     simp.net
-Kickstart server     192.168.1.10
-Yum server           192.168.1.10
-LDAP URI             ldap://puppet.simp.net
-LDAP Base DN         [dc=simp,dc=net]
-LDAP Root DN         [cn=LDAPAdmin,ou=People,dc=simp,dc=net]
-LDAP Bind DN         [cn=hostAuth,ou=Hosts,dc=simp,dc=net]
-LDAP Sync DN         [cn=LDAPSync,ou=People,dc=simp,dc=net]
-==================== =====
-
-Table: Sample values for SIMP install
+A table of settings that can be changed/defined during installation is located in Appendix B, :ref:`List of Installation Variables`.
+Review this if you are unfamiliar with SIMP.  
 
 Preparing the SIMP Server Environment
 -------------------------------------
@@ -124,16 +77,24 @@ Preparing the SIMP Server Environment
 Installing the SIMP Server
 --------------------------
 
+..  warning::
+    Keep in mind as the installation process begins that Puppet does not
+    work well with capital letters in host names. Therefore, they should
+    not be used.
+
 1. Log on as ``simp`` and run ``su -`` to gain root access.
 2. Type ``simp config``
 
   a. Type ``simp config -a <Config File>`` to load a previously generated configuration instead of generating the configuration from the script. This is the option to run for systems that will be rebuilt often.
   b. For a list of additional commands, type ``simp help``. Type ``simp help ***<Command>***`` for more information on a specific command.
+  c.  A list of the variables that are set and more details are contained in :ref:`List of Installation Variables`.
+
+.. note:: Once simp config has been run, a simp config file with all your settings is saved in /root/.simp/simp_conf.yaml
 
 3. Configure the system as prompted.
 4. Type ``simp bootstrap``
 
-  .. note:: If progress bars are of equal length and the bootstrap finishes quickly, a problem has occurred. This is most likely due to an error in SIMP configuration. Refer to the previous step and make sure that all configuration options are correct.
+.. note:: If progress bars are of equal length and the bootstrap finishes quickly, a problem has occurred. This is most likely due to an error in SIMP configuration. Refer to the previous step and make sure that all configuration options are correct.
 
 5. Type ``reboot``
 

--- a/docs/installation_guide/index.rst
+++ b/docs/installation_guide/index.rst
@@ -9,11 +9,11 @@ Contents:
   SIMP_Server_Installation
   Client_Management
   Certificates
-  PXE_Boot
   Hiera_Overview
   Changelog <../common/Changelog.rst>
   Glossary <../common/Glossary.rst>
   File_Samples
+  AppendixB
 
 Indices and tables
 ------------------

--- a/docs/sample/dhcpd.conf
+++ b/docs/sample/dhcpd.conf
@@ -23,8 +23,8 @@ subnet 192.168.122.0 netmask 255.255.255.0 {
 
   # We explicitly list our hosts to restrict the hosts that can access our
   # network.
-#  host sample {
-#    hardware ethernet DE:AD:BE:EF:00:00;
-#    fixed-address 192.168.122.16;
-#  }
+  host sample {
+    hardware ethernet DE:AD:BE:EF:00:00;
+    fixed-address 192.168.122.16;
+  }
 }

--- a/docs/user_guide/PXE_Boot.rst
+++ b/docs/user_guide/PXE_Boot.rst
@@ -1,1 +1,0 @@
-.. include:: ../common/PXE_Boot.rst

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -10,7 +10,6 @@ Contents:
   User_Management
   Client_Management
   Certificates
-  PXE_Boot
   Maximum_Nodes
   SIMP_Administration
   Puppetmaster_Backup


### PR DESCRIPTION
This update rewrote the PXE boot section and put it in order.  
Put in updates where 4.2 and 5.1 docs differed.
 Updated SIMP install portion to list out all variables that can be set and started to describe these settings.

SIMP-323 #comment Documentation Updates