### PR TITLE
(SIMP-557) Add web server to rake tasks

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,20 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exists?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+guard 'rake', :task => 'docs:html' do
+  watch(%r{^docs/^.+(^Changelog.rst)})
+end

--- a/README.md
+++ b/README.md
@@ -9,15 +9,3 @@ This is a component of the [System Integrity Management Platform](https://github
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
 Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP) and visit our [developer wiki](https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home).
-
-# NOTE: THIS REPOSITORY IS IN A TRANSITIONAL STATE
-
-### NOTES
-* The `Rakefile` currently builds the publican documentation (deprecated).
-* The `.travis.yml` is targeted at building the reStructuredText docs (in progress).
-
-### TODO
-- [X] TravisCI tests
-- [X] Port Publican documentation to rst
-- [X] Remove Publican documentation
-- [ ] update & vet documentation against current SIMP version

--- a/Rakefile
+++ b/Rakefile
@@ -112,4 +112,11 @@ namespace :docs do
     puts "== #{cmd}"
     %x(#{cmd} > /dev/null)
   end
+
+  desc 'run a local web server to view HTML docs on http://localhost:5000'
+  task :server, [:port] do |_t, args|
+    port = args.to_hash.fetch(:port, 5000)
+    puts "running web server on http://localhost:#{port}"
+    %x(ruby -run -e httpd html/ -p #{port})
+ end
 end

--- a/docs/_static/css_overrides.css
+++ b/docs/_static/css_overrides.css
@@ -14,8 +14,15 @@ code, .rst-content tt, .rst-content code {
 
 /*
  * === SIMP-specific styling ===
- *
- * menu text colors
+*/
+ 
+/* link colors
+ * -------------------------------------------------------------------------- */
+a         { color: #336633; }
+a:visited { color: #80b980; }
+a:hover   { color: #29b929; }
+
+/* menu text colors
  * -------------------------------------------------------------------------- */
 .wy-menu-vertical li.on a, .wy-menu-vertical li.current>a {
   color: #003300;


### PR DESCRIPTION
This commit adds a `Guardfile` and a new rake task `docs:server` to
support automatic html builds and ihtml review via a local web browser.

SIMP-557 #comment Added a `Guardfile` and a new rake tast `docs:server`.
SIMP-557 #comment Updated hyperlinks to theme-appropriate colors.

Change-Id: Ic272da2e54aecce42be77c9a38bcf4f81427c037