### PR TITLE
(SIMP-687) Update to note dependency fix

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,5 +1,5 @@
 =========================
-SIMP 5.1.0-1
+SIMP 5.1.0-2
 =========================
 
 ---------
@@ -16,9 +16,9 @@ Changelog
 
   PageBreak
 
-SIMP 5.1.0-0
+SIMP 5.1.0-2
 
-**Package**: 5.1.0-0
+**Package**: 5.1.0-2
 
 This release is known to work with:
 

--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -7,7 +7,7 @@
 Summary: SIMP Documentation
 Name: simp-doc
 Version: 5.1.0
-Release: 1
+Release: 2
 License: Apache License, Version 2.0
 Group: Documentation
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -88,6 +88,9 @@ mv pdf/SIMP_Documentation.pdf pdf/SIMP-%{version}-%{release}.pdf
 # Post uninstall stuff
 
 %changelog
+* Wed Nov 11 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-2
+- Update to fix SIMP RPM dependencies
+
 * Wed Nov 11 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-0
 - Updated the default passwords to be easier overall
 

--- a/docs/user_guide/SIMP_RPM_List.csv
+++ b/docs/user_guide/SIMP_RPM_List.csv
@@ -81,7 +81,7 @@ rubygem-simp-cli,1.0.10-0.el7,**true**
 rubygem-simp-cli-doc,1.0.10-0.el7,**true**
 simp,5.1.0-RC1.1446834077,**true**
 simp-bootstrap,5.2.1-1,**true**
-simp-doc,5.1.0-0,**true**
+simp-doc,5.1.0-2,**true**
 simp-gpgkeys,2.0.0-3.el7,**true**
 simp-rsync,5.1.0-2.el7,**true**
 simp-rsync-clamav,5.1.0-2.el7,**true**


### PR DESCRIPTION
The main SIMP RPM did not have the correct dependency chain in place in
the 5.1.0-0 release.

SIMP-687 #comment Doc update