### PR TITLE
(SIMP-586) Documentation Spell Check Fixes

### DIFF
--- a/docs/common/PXE_Boot.rst
+++ b/docs/common/PXE_Boot.rst
@@ -16,11 +16,6 @@ This section describes how to configure the kickstart server.
     A.  ``pupclient_x86_64.cfg``
     B.  ``diskdetect.sh``
 2. Open each of the files and follow the instructions provided within them to replace the variables. You need to know the IP Addresses of the YUM, Kickstart, and TFTPserver. (They default to the simp server in simp config).  
-    A. ``pupclient_x86_64.cfg``:   
-        1.) Note: #KSSERVER# should be replaced with Kickstart Server IP not Yum IP.  (They are the same if you used the defaults.)
-        2.) In the URL line use the YUMSERVER ip not the Kickstart server IP. (Although on a default SIMP system the YUM and kicktart server are the same server so it is not a problem.)
-        3.) Use the commands in the top of the file in the comments section to generate the password hashes.  
-    B. ``diskdetect.sh``:  The ``diskdetect.sh`` script is responsible for detecting the first active disk and applying a disk configuration. Edit this file to meet any necessary requirements or use this file as a starting point for further work. It will work as is for most systems as long as your disk device names are in the list.
 3. Type ``chown root.apache /var/www/ks/*`` to ensure that all files are owned by ``root`` and in the ``apache`` group.
 4. Type ``chmod 640 /var/www/ks/*`` to change the permissions so the owner can read and write the file and the ``apache`` group can only read. 
 

--- a/docs/security_conop/Appendix_KS.rst
+++ b/docs/security_conop/Appendix_KS.rst
@@ -16,7 +16,7 @@ Default Puppet Master Kickstart file (contains default RPMs)
     # Replace the following strings in this file
     # #BOOTPASS# - Your hashed bootloader password
     # #ROOTPASS# - Your hashed root password
-    # #KSSERVER# - The IP address of your YUM server
+    # #KSSERVER# - The IP address of your Kickstart server
     # #YUMSERVER# - The IP address of your YUM server
     # #LINUXDIST# - The LINUX Distribution you are kickstarting
     #        - Current CASE SENSITIVE options: RedHat CentOS
@@ -41,7 +41,7 @@ Default Puppet Master Kickstart file (contains default RPMs)
     text
     keyboard us
     lang en_US
-    url --url http://#KSSERVER#/yum/#LINUXDIST#/7/x86_64
+    url --url http://#YUMSERVER#/yum/#LINUXDIST#/7/x86_64
 
     %include /tmp/part-include
 

--- a/docs/security_conop/Appendix_SCTM.rst
+++ b/docs/security_conop/Appendix_SCTM.rst
@@ -1234,7 +1234,7 @@ SIMP SCTM Management Controls
    * - CM-8(2)
      - Information System Component Inventory (Control Enhancement)
      - Configuration Management
-     - To the extent possible, puppet tracks clients that are within it's control. It's not meant to be a true inventory mechanism.
+     - To the extent possible, puppet tracks clients that are within its control. It's not meant to be a true inventory mechanism.
    * - CM-8(3)
      - Information System Component Inventory (Control Enhancement)
      - Configuration Management
@@ -2010,7 +2010,7 @@ SIMP SCTM Management Controls
    * - SI-7
      - Software and Information Integrity
      - System and Information Integrity
-     - SIMP comes with AIDE installed. Puppet also serves the purpose of checking the integrity of files. During each client run, a change in file integrity means the file needs to be restored to it's original state.
+     - SIMP comes with AIDE installed. Puppet also serves the purpose of checking the integrity of files. During each client run, a change in file integrity means the file needs to be restored to its original state.
    * - SI-7(1)
      - Software and Information Integrity (Control Enhancement)
      - System and Information Integrity
@@ -2194,11 +2194,11 @@ SIMP SCTM Management Controls
    * - RA-5(1)
      - Vulnerability Scanning (Control Enhancement)
      - Risk Assessment
-     - SCAP-Security-Guide is the two primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
+     - SCAP-Security-Guide is the primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
    * - RA-5(2)
      - Vulnerability Scanning (Control Enhancement)
      - Risk Assessment
-     - SCAP-Security-Guide is the two primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
+     - SCAP-Security-Guide is the primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
    * - RA-5(3)
      - Vulnerability Scanning (Control Enhancement)
      - Risk Assessment


### PR DESCRIPTION
A few more minor spell check errors were found and fixed.  I also removed
comments that corrected errors in PXE boot build that were fixed in
another ticket but the docs were not updated.

SIMP-586 #close