### PR TITLE
(SIMP-703) Update Redundant LDAP Server Documentation

### DIFF
--- a/docs/user_guide/FAQs/Redundant_LDAP.rst
+++ b/docs/user_guide/FAQs/Redundant_LDAP.rst
@@ -1,127 +1,189 @@
 Redundant LDAP
-==============
+===============
 
-This section describes how to set up redundant OpenLDAP servers in SIMP.
+This section describes how to set up redundant OpenLDAP servers in SIMP.  These servers are also refered to as slave servers.
 
-The version of OpenLDAP in RHEL5 only supports *syncrepl*. Multi-master
-replication has been added in a more recent version of OpenLDAP but is
-not currently supported in SIMP. *Syncrepl* is optimal for :term:`Wide Area Network` (WAN) situations
-and is the SIMP default.
 
 Set up the Master
------------------
+------------------
 
-If the standard ``puppet_servers.pp`` file in SIMP is being used, the
-user has a working master server. If not, the following example
-demonstrates how to use the SIMP *openldap* module to create a server
-using the ``puppet_servers.pp`` file .
+The easiest way to setup an ldapmaster is to set it up on the puppet master using simp config during the initial configuration of the puppet server. This is done by answering "YES" to "use ldap?" query when you run simp config and answering the basic questions it asks you.  
+If it is not desirable to have the ldap server on the Puppet server a redundant LDAP server can be set up on an alternate server and promoted to master using the directions below. 
 
-Source Code for Using an OpenLDAP Server openldap
+How ever if there is already a working infrastructure and you want to move to openldap
+you can do the following:
+
+eonfigure the following settings in ``simp_def.yaml`` in the hiera directory:
+
+.. code-block:: yaml
+
+ # === use_ldap ===
+ # Whether or not to use LDAP on this system.
+ # If you disable this, modules will not attempt to use LDAP where possible.
+ use_ldap: true
+ 
+ # === ldap::base_dn ===
+ # The Base DN of the LDAP server
+ "ldap::base_dn": "dc=your,dc=domain"
+
+ # === ldap::bind_dn ===
+ # LDAP Bind Distinguished Name
+ "ldap::bind_dn": "cn=hostAuth,ou=Hosts,%{hiera('ldap::base_dn')}"
+
+ # === ldap::bind_pw ===
+ # The LDAP bind password
+ "ldap::bind_pw": "MyRandomlyGeneratedLargePassword"
+
+ # === ldap::bind_hash ===
+ # The salted LDAP bind password hash
+ "ldap::bind_hash": "{SSHA}9nByVJSZFBe8FfMkar1ovpRxJLdB0Crr"
+
+ # === ldap::sync_dn ===
+ # 
+ "ldap::sync_dn": "cn=LDAPSync,ou=Hosts,%{hiera('ldap::base_dn')}"
+
+ # === ldap::sync_pw ===
+ # The LDAP sync password
+ "ldap::sync_pw": "MyOtherRandomVeryLargePassword"
+
+ # === ldap::sync_hash ===
+ # The SSHA hash for ldap::sync_pw
+ "ldap::sync_hash": "{SSHA}VlgYUmRzyuuKZXM3L8RT28En/eqtuTUO"
+
+ # === ldap::root_dn ===
+ # The LDAP root DN.
+ "ldap::root_dn": "cn=LDAPAdmin,ou=People,%{hiera('ldap::base_dn')}"
+
+ # === ldap::root_hash ===
+ # The LDAP root password hash.
+ #  If you set this with simp config, type the password and the hash will be
+ # generated for you.' 
+ "ldap::root_hash": "{SSHA}GSCDnNF6KMXBf1F8eIe5xvQxVJou3zGu"
+
+ # === ldap::master ===
+ # This is the LDAP master in URI form (ldap://server)
+ "ldap::master": "ldap://ldap_server1.your.domain"
+
+ # === ldap::uri ===
+ # List of OpenLDAP servers in URI form (ldap://server)
+ "ldap::uri": 
+   - "ldap://ldap_server1.your.domain"
+ 
+ # === sssd::domains ===
+ # A list of domains for SSSD to use.
+ # `simp config` will automativcally populate this field with `FQDN` if
+ # `use_fqdn` is true, otherwise it will comment out the field.
+ # 
+ "sssd::domains": 
+   - LDAP
+
+
+Add the ldap class into the yaml file for the ldap server in Hiera (hieradata/hosts/ldap_server1.your.domain.yaml)
+
+.. code-block:: yaml
+
+ classes :
+   - 'simp::ldap_server'
+
+Leave any other classes that are there if they are needed.  Run the puppet agent on the ldap server until it runs cleanly. Run the agent on the puppet server.  Onces all the other clients update against the Puppet server they will be able to authenticate against the LDAP server.  Adding users and groups is described in the :ref:`User_Management`.
+
+.. note::
+ 
+ Information on how the create salted ({SSHA}) passwords can be found at the `OpenLDAP site <http://www.openldap.org/faq/data/cache/347.html>`__.
+
+
+Set up the Redundant(Slave) Servers
+------------------------------------
+
+Default Settings
+~~~~~~~~~~~~~~~~~
+
+Once the master is ready, LDAP slave nodes can be configured to replicate data from the master. These servers are read only and modifications can not be made to LDAP enries while the master is down.  
+
+Slave nodes can be configured by declaring the server a ldap slave, setting the replication id and adding the class in the hiera data.  This will set up your redundant server using the defaults. To do these three things, add the following lines to the ``hieradata/hosts/ldap_server2.your.domain.yaml`` file:
+
+.. code-block:: yaml
+
+ simp::ldap_server::is_slave : true
+ simp::ldap_server::rid  : "888"
+ 
+ classes :
+    - 'simp::ldap_server'
+
+.. _URI:
+
+To make other clients aware of this server, add the redundant server's URI to lists of URIs in the ``hieradata/simp_def.yaml`` file:
+
+.. code-block:: yaml
+
+ # === ldap::uri ===
+ # List of OpenLDAP servers in URI form (ldap://server)
+ "ldap::uri": 
+   - "ldap://ldap_server1.your.domain"
+   - "ldap://ldap_server2.your.domain"
+
+.. note::
+   
+ To see the defaults for LDAP replication in SIMP, review the parameters passed to the module ``openldap/manifests/server/syncrepl.pp``. These parameters are used to add the replication settings to the ``syncrepl.conf`` file.  Definitions can be found in the syncrepl.conf (5) man page.
+
+
+Custom Settings
+~~~~~~~~~~~~~~~~
+
+If settings other than the defaults are needed, create a manifest to call the openldap::server::syncrepl class with the parameters needed. In this example the class is called ldapslave and is a child of site and the RID of the server is 999, these can be changed.  One setting, sizelimit, is being overwriten but you can overwrite any number of them. 
 
 .. code-block:: ruby
 
-  # These are some common variables.
-  # See /etc/puppet/manifests/vars.pp for the stock version.
+ class site::ldapslave {
 
-  $ldap_master = 'ldap://ldapmaster.your.domain'
+   include 'simp::ldap_server'
 
-  class ldap_common {
-    include 'openldap::slapd_pki'
+   openldap::server::syncrepl { '999':
+     sizelimit  => '5000',
+   }
+ }
 
-    openldap::slapd::conf { 'default':
-      suffix => 'dc=your,dc=domain',
-      rootdn => 'dn=LDAPAdmin,ou=People,dc=your,dc=domain',
-      rootpw => '{SSHA}$klskf$asoghaagasgasgaggawawg',
-      tlsCertificateFile => "/etc/pki/public/${fqdn}.pub",
-      tlsCertificateKeyFile => "/etc/pki/private/${fqdn}.pem",
-      client_nets => [ '1.2.3.4/16' ]
-    }
-  }
+The name of the openldap::server::syncrepl instance must be a unique replication id.
 
-  class ldap_master inherits ldap_common {
-    include 'openldap::slapo::syncprov'
+Place this file in the site manifests directory calling it by the class name, in this instance ldapslave.pp and call this class from the slave server's hiera .yaml file:  
 
-    openldap::slapo::syncprov::conf { "default": }
-  }
+.. code-block:: yaml
 
-  node ldapmaster {
-    include 'ldap_master'
-  }
+ classes : 
+ - 'site::ldapslave'
 
-.. _Redundant_LDAP-Replicants:
 
-Set up the Replicated Servers
------------------------------
-
-Once the master is ready, LDAP slave nodes must be configured to
-replicate data from the master. The example below shows an the code that
-should be added to the slave node in Puppet. The actual order of which
-gets done first is irrelevant; the replicated servers will attempt to
-contact the master until they are successful.
-
-Source Code to Configure an LDAP Slave Node replication
-
-.. code-block:: ruby
-
-  class ldap_repl inherits ldap_common {
-    include 'openldap::slapd::syncrepl'
-
-    openldap::slapd::syncrepl::conf { "111":
-      provider => $ldap_master,
-      syncrepl_retry => '60 10 600 +',
-      searchbase => 'dc=your,dc=domain',
-      starttls => 'critical',
-      bindmethod => 'simple',
-      binddn => 'cn=LDAPSync,ou=People,dc=your,dc=domain',
-      credentials => '<plain text password>',
-      updateref => $ldap_master
-    }
-  }
-
-  node ldaprepl1 {
-    include "ldap_repl"
-  }
-
-  node ldaprepl2 {
-    include "ldap_repl"
-  }
-
+Lastly, add the server to the URI_ listing in simp_def.yaml so all the clients know about it once they have updated from the puppet master.
 
 Promote a Slave Node
---------------------
+---------------------
 
-Slave nodes can be promoted to act as the LDAP master node. To do this,
-change the node classifications of the relevant hosts. The following
-example shows the promotion of the *ldaprepl1* server to the master
-server.
+Slave nodes can be promoted to act as the LDAP master node. To do this, change the node classifications of the relevant hosts. 
+For a node with the default settings, just remove the ``simp::ldap_server::is_slave : true`` from the server's hiera .yaml file and change the setting for the master ldap in the ``simp_def.yaml``.
 
-Source Promoting a Slave Node LDAP
+.. code-block:: yaml
 
-.. code-block:: ruby
+ # === ldap::master ===
+ # This is the LDAP master in URI form (ldap://server)
+ "ldap::master": "ldap://ldap_server1.your.domain"  
 
-  # Change the common ldap server variable to promote the slave node.
+For a redundant server set up using custom settings, remove the call to the custom class and replace it with the call to the site::ldap_server class in the servers yaml file and set the master setting in the ``simp_def.yaml`` file as shown above.
 
-  $ldap_master = 'ldap://ldaprepl1.your.domain'
+In both cases, if the current master is not down, make sure it has completed replication before changing the settings.  Once the settings are changed, run puppet agent -t on the ldap server. After the next Puppet run on all the hosts the server will be promoted to master and all the slaves will point to it. 
 
-  node ldapmaster {
-    # include 'ldap_master'
-  }
+Remove a Node or Demote a Master
+---------------------------------
 
-  node ldaprepl1 {
-    # include 'ldap_repl'
-    include 'ldap_master'
-  }
+To demote a master, simply configure it as slave in either of the configurations above after the new master has been configured and put in place, then run the puppet agent.  Lastly, manually remove the active database from the server. (Check the setting ``openldap::server::conf::directory`` setting for the location of the files.)
 
-
-After the next Puppet run on all hosts, *ldaprepl1* will be promoted to
-the master and all slave nodes will point to it.
+To remove an LDAP server, first remove the server from the URI_  settings in ``simp_def.yaml``.  Give the clients time to update from the puppet server so they do not attempt to call it.  Then remove relevant settings from it's hiera .yaml file and run the puppet agent.  
 
 Troubleshooting
----------------
+----------------
 
 If the system is not replicating, it is possible that another user has
 updated the ``$ldap_sync_passwd`` and ``$ldap_sync_hash`` entries in the
-``/etc/puppet/manifests/vars.pp`` file without also updating the value in
+``/etc/puppet/environments/simp/simp_def.yaml`` file without also updating the value in
 LDAP itself; this is the most common issue reported by users.
 
 Currently, SIMP cannot self-modify the LDAP database directly;
@@ -133,7 +195,7 @@ The example below shows the changes necessary to update the
 
 Update ``$ldap_sync`` Information in LDAP Examples
 
-.. code-block:: ruby
+.. code-block:: yaml
 
   dn: cn=LDAPSync,ou=People,dc=your,dc=domain
   changetype: modify
@@ -141,14 +203,8 @@ Update ``$ldap_sync`` Information in LDAP Examples
   userPassword: <Hash from $ldap_sync_hash>
 
 
-Master Node Demotion
-~~~~~~~~~~~~~~~~~~~~
+Further Information
+--------------------
 
-In the event that multiple master nodes have been set up, it may be
-necessary to demote one or more of them to slave instances. To do this,
-add the replication code shown in the previous section titled :ref:`Redundant_LDAP-Replicants` to the
-manifest of the master node being demoted.
+The `OpenLDAP site <http://www.openldap.org/doc/admin24/intro.html>`__ contains more information on configuring and maintaining Open LDAP servers.
 
-Once this is complete, manually remove the active database from the LDAP
-server being demoted and then run Puppet. The SIMP team is working to
-enable SIMP to handle this transition automatically in the future.


### PR DESCRIPTION
This updates the documentation explaining how to make a server
built with SIMP a redundant LDAP server.

SIMP-703 #close