### PR TITLE
(SIMP-587) Update docs to use https for YUM

### DIFF
--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -7,7 +7,7 @@
 Summary: SIMP Documentation
 Name: simp-doc
 Version: 5.1.0
-Release: 2
+Release: 4.Alpha
 License: Apache License, Version 2.0
 Group: Documentation
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -88,6 +88,10 @@ mv pdf/SIMP_Documentation.pdf pdf/SIMP-%{version}-%{release}.pdf
 # Post uninstall stuff
 
 %changelog
+* Mon Apr 04 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-4.Alpha
+- Starting on the 5.1.0-4 release...
+- Changed the tftpboot docs to use https.
+
 * Wed Nov 11 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-2
 - Update to fix SIMP RPM dependencies
 

--- a/docs/common/PXE_Boot.rst
+++ b/docs/common/PXE_Boot.rst
@@ -90,7 +90,7 @@ Create a site manifest for the TFTP server on the Puppet server.
     tftpboot::linux_model { 'MODEL NAME':
       kernel => 'OSTYPE-MAJORRELEASE-ARCH/vmlinuz',
       initrd => 'OSTYPE-MAJORRELEASE-ARCH/initrd.img',
-      ks     => "http://KSSERVER/ks/pupclient_x86_64.cfg",
+      ks     => "https://KSSERVER/ks/pupclient_x86_64.cfg",
       extra  => "ksdevice=bootif\nipappend 2"
     }
 

--- a/docs/installation_guide/Hiera_Overview.rst
+++ b/docs/installation_guide/Hiera_Overview.rst
@@ -86,7 +86,7 @@ Add the following code to a file tftpboot.pp in your site/manifests directory:
           tftpboot::linux_model { 'EL_MAJOR_VERSION':
             kernel => 'EL_MAJOR_VERSION_x86_64/vmlinuz',
             initrd => 'EL_MAJOR_VERSION_x86_64/initrd.img',
-            ks     => "http://KSSERVER/ks/pupclient_x86_64.cfg",
+            ks     => "https://KSSERVER/ks/pupclient_x86_64.cfg",
             extra  => 'ipappend 2'
           }
 


### PR DESCRIPTION
Updated the docs to use https for the kickstart process.

SIMP-587 #comment Doc update for https change for YUM

Change-Id: I1e790d43058e79227a0ef63fb224a94ecfe07285