### PR TITLE
(SIMP-993) Update to properly build the PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-rst/_build
-docs/_build
-docs/*/Changelog.rst
-_build_v5
-_build_v4
 .sw[pnoqst]
+_build_v4
+_build_v5
 builderrors
+dist
+docs/*/Changelog.rst
+docs/_build
 html
 pdf
+rst/_build
 sphinx_cache

--- a/Rakefile
+++ b/Rakefile
@@ -216,7 +216,7 @@ namespace :docs do
   desc 'build PDF docs (SLOW)'
   task :pdf do
     extra_args = ''
-    cmd = "sphinx-build -E -n #{extra_args} -b pdf -d sphinx_cache docs pdf"
+    cmd = "sphinx-build -T -E -n #{extra_args} -b pdf -d sphinx_cache docs pdf"
     puts "== #{cmd}"
     %x(#{cmd} > /dev/null)
   end

--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -7,7 +7,7 @@
 Summary: SIMP Documentation
 Name: simp-doc
 Version: 4.2.0
-Release: 3.Alpha
+Release: 3.Alpha.1
 License: Apache License, Version 2.0
 Group: Documentation
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -50,20 +50,16 @@ source /opt/rh/python27/enable
 
 virtualenv venv
 source venv/bin/activate
-pip install --upgrade sphinx
-pip install --upgrade rst2pdf
-pip install --upgrade pillow
-pip install --upgrade svglib
-pip install --upgrade sphinxcontrib-findanything
+pip install --upgrade -r requirements.txt
 
-sphinx-build -E -n -t simp_%{simp_major_version} -b html       -d sphinx_cache docs html
+sphinx-build -E -n -t simp_%{simp_major_version} -b html -d sphinx_cache docs html
 sphinx-build -E -n -t simp_%{simp_major_version} -b singlehtml -d sphinx_cache docs html-single
 
 # Rst2pdf is currently broken on references so we have to remove them.
 # This should be removed when this bug is fixed.
 find docs -name "*.rst" -exec sed -i 's/:ref://g' {} \;
 
-sphinx-build -E -n -t simp_%{simp_major_version} -b pdf        -d sphinx_cache docs pdf
+sphinx-build -E -n -t simp_%{simp_major_version} -b pdf -d sphinx_cache docs pdf
 
 if [ ! -s pdf/SIMP_Documentation.pdf ]; then
   echo "ERROR: Could not generate PDF"
@@ -74,6 +70,11 @@ fi
 
 if [ ! -d changelogs ]; then
   mkdir changelogs
+fi
+
+if [ ! -f pdf/SIMP_Documentation.pdf ] || [ `stat --printf="%s" pdf/SIMP_Documentation.pdf` ]; then
+  echo "Error: PDF output has size 0"
+  exit 1
 fi
 
 %install
@@ -93,9 +94,11 @@ fi
 # Post uninstall stuff
 
 %changelog
-* Tue Apr 05 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.0-3.Alpha
+* Tue Apr 05 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.0-3.Alpha.1
 - Prepare for the next release
 - Changed the tftpboot docs to use https.
+- Fixed a bug that was preventing PDF builds
+- Updated the RPM build to fail if the resulting PDF is size 0
 
 * Wed Dec 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.0-1
 - Doc updates for 4.2.0-1

--- a/docs/security_conop/Appendix_SCTM.rst
+++ b/docs/security_conop/Appendix_SCTM.rst
@@ -357,7 +357,16 @@ SIMP SCTM Technical Controls
    * - AU-2
      - Auditable Events
      - Audit and Accountability
-     - a. SIMP audit rules were built by using idustry best practices gathered over the years. The heaviest reliance has been on the SCAP-Security Guide (SSG). SIMP aims for a balance between performance and operational needs so the settings are rarely an exact match from these guides. The list of events that audited are by auditd can be found in appendix of the Security Concepts document. b. Implementation Specific c. Rational is for audit setting is provided in SSG. d. Threat information is specific to the implementation. Auditd and syslog facility can always be fine tuned for each implementation.
+     - a. SIMP audit rules were built by using industry best practices gathered
+          over the years. The heaviest reliance has been on the SCAP-Security
+          Guide (SSG). SIMP aims for a balance between performance and
+          operational needs so the settings are rarely an exact match from
+          these guides. The list of events that audited are by auditd can be
+          found in appendix of the Security Concepts document.
+       b. Implementation Specific
+       c. Rationale is for audit setting is provided in SSG. d. Threat
+          information is specific to the implementation. Auditd and syslog
+          facility can always be fine tuned for each implementation.
    * - AU-2(3)
      - Auditable Events (Control Enhancement)
      - Audit and Accountability
@@ -381,11 +390,18 @@ SIMP SCTM Technical Controls
    * - AU-4
      - Audit Storage Capacity
      - Audit and Accountability
-     - The audit partition is configured as a separation partition from the system files, reducing the likelihood of audit interfering with system operations. Implementaions can change this but it's highly discouraged.
+     - The audit partition is configured as a separation partition from the system files, reducing the likelihood of audit interfering with system operations. Implementations can change this but it's highly discouraged.
    * - AU-5
      - Response to Audit Processing Failures
      - Audit and Accountability
-     - a. Implementation Specific. b. The audit.conf file configures the system to log to syslog when disk space becomes low. If the disk becomes full, the audit daemon will be suspended, but the system will remain active. This is contrary to some industry guidance to put the system into single user mode when disk space becomes an issue. Implementations may wish to change the default behaviour at the risk of stopping the system from functioning.
+     - a. Implementation Specific.
+       b. The audit.conf file configures the system to log to syslog when disk
+          space becomes low. If the disk becomes full, the audit daemon will be
+          suspended, but the system will remain active. This is contrary to
+          some industry guidance to put the system into single user mode when
+          disk space becomes an issue. Implementations may wish to change the
+          default behaviour at the risk of stopping the system from
+          functioning.
    * - AU-5(1)
      - Response to Audit Processing Failures (Control Enhancement)
      - Audit and Accountability
@@ -505,7 +521,11 @@ SIMP SCTM Technical Controls
    * - AU-12
      - Audit Generation
      - Audit and Accountability
-     - a. Auditd provides the audit generation capability and is running on all SIMP systems by default.b. The audit.rules files configures events that are audited. c. The audit.rules applies the list of audit rules defined in SIMP Security Concepts document.
+     - a. Auditd provides the audit generation capability and is running on all
+          SIMP systems by default.
+       b. The audit.rules files configures events that are audited.
+       c. The audit.rules applies the list of audit rules defined in SIMP
+          Security Concepts document.
    * - AU-12(1)
      - Audit Generation (Control Enhancement)
      - Audit and Accountability
@@ -613,7 +633,19 @@ SIMP SCTM Technical Controls
    * - IA-5(1)
      - Authenticator Management (Control Enhancement)
      - Identification and Authentication
-     - a. Authenticator strength is enforced using pam\_crack\_lib.so. This works for user defined passwords on local and LDAP accounts. Administrators can bypass PAM and set weak passwords in LDAP. Under normal circumstances, users would be forced to change their password at login, at which point pam enforced complexity. b. Not enforced c. Hashed passwords are built into linux (/etc/shadow and /etc/pam.d/system-auth pam\_unix.so). LDAP password changed by users are done through pam before getting placed in LDAP. Manual LDAP password are created using the slapasswd command.d. Password minimum and maximum lifetimes are enforced through /etc/login.defs and ldap. e. By default, the previous 24 passwords can not be reused.
+     - a. Authenticator strength is enforced using pam\_crack\_lib.so. This
+          works for user defined passwords on local and LDAP accounts.
+          Administrators can bypass PAM and set weak passwords in LDAP. Under
+          normal circumstances, users would be forced to change their password
+          at login, at which point pam enforced complexity.
+       b. Not enforced.
+       c. Hashed passwords are built into linux (/etc/shadow and
+          /etc/pam.d/system-auth pam\_unix.so). LDAP password changed by users
+          are done through pam before getting placed in LDAP. Manual LDAP
+          password are created using the slapasswd command.
+       d. Password minimum and maximum lifetimes are enforced through
+          /etc/login.defs and ldap.
+       e. By default, the previous 24 passwords can not be reused.
    * - IA-5(2)
      - Authenticator Management (Control Enhancement)
      - Identification and Authentication
@@ -1113,7 +1145,14 @@ SIMP SCTM Management Controls
    * - CM-2(5)
      - Baseline Configuration (Control Enhancement)
      - Configuration Management
-     - a. SIMP provides a minimal list of packages and services installed. The minimal list of packages can be found in kickstart files and the appendix of this document. Additional packages are installed by each implementation or as SIMP modules are applied. b. It's not feasible to technically deny additional applications from being installed. There is nothing in SIMP that can stop and RPM from being applied. Applications that require network access to service activation must be registered with puppet.
+     - a. SIMP provides a minimal list of packages and services installed. The
+          minimal list of packages can be found in kickstart files and the
+          appendix of this document. Additional packages are installed by each
+          implementation or as SIMP modules are applied.
+       b. It's not feasible to technically deny additional applications from
+          being installed. There is nothing in SIMP that can stop and RPM from
+          being applied. Applications that require network access to service
+          activation must be registered with puppet.
    * - CM-2(6)
      - Baseline Configuration (Control Enhancement)
      - Configuration Management
@@ -1225,7 +1264,7 @@ SIMP SCTM Management Controls
    * - CM-8(2)
      - Information System Component Inventory (Control Enhancement)
      - Configuration Management
-     - To the extent possible, puppet tracks clients that are within it's control. It's not meant to be a true inventory mechanism.
+     - To the extent possible, puppet tracks clients that are within its control. It's not meant to be a true inventory mechanism.
    * - CM-8(3)
      - Information System Component Inventory (Control Enhancement)
      - Configuration Management
@@ -1545,7 +1584,7 @@ SIMP SCTM Management Controls
    * - MA-4(1)
      - Non-Local Maintenance (Control Enhancement)
      - Maintenance
-     - Remote maintenance can be performed on SIMP using SSH or direct console access. SSH sessions are tracked and logged using the security features built into SIMP. Console access requires someone to have access to the physical (or virtual) console along with the root password. Audting of those actions also occurs in accordance with the configured audit policy. It's up to the implementation to decide how to distribute authentication information for remote maintenance
+     - Remote maintenance can be performed on SIMP using SSH or direct console access. SSH sessions are tracked and logged using the security features built into SIMP. Console access requires someone to have access to the physical (or virtual) console along with the root password. Auditing of those actions also occurs in accordance with the configured audit policy. It's up to the implementation to decide how to distribute authentication information for remote maintenance
    * - MA-4(2)
      - Non-Local Maintenance (Control Enhancement)
      - Maintenance
@@ -1877,7 +1916,7 @@ SIMP SCTM Management Controls
    * - SI-3
      - Malicious Code Protection
      - System and Information Integrity
-     - SIMP has modules available for mcafee and ClamAV. The ClamAV. Implementations need need to provide their own version of the mcafee software for the module to work. That module comes with the ability to sync dat updates to clients via rsync. The modulde does NOT specify how often and what files systems should be scanned. SIMP also implements the open source tool chkrootkit that comes installed by default.
+     - SIMP has modules available for mcafee and ClamAV. The ClamAV. Implementations need need to provide their own version of the mcafee software for the module to work. That module comes with the ability to sync dat updates to clients via rsync. The module does NOT specify how often and what files systems should be scanned. SIMP also implements the open source tool chkrootkit that comes installed by default.
    * - SI-3(1)
      - Malicious Code Protection (Control Enhancement)
      - System and Information Integrity
@@ -2001,7 +2040,7 @@ SIMP SCTM Management Controls
    * - SI-7
      - Software and Information Integrity
      - System and Information Integrity
-     - SIMP comes with AIDE installed. Puppet also serves the purpose of checking the integrity of files. During each client run, a change in file integrity means the file needs to be restored to it's original state.
+     - SIMP comes with AIDE installed. Puppet also serves the purpose of checking the integrity of files. During each client run, a change in file integrity means the file needs to be restored to its original state.
    * - SI-7(1)
      - Software and Information Integrity (Control Enhancement)
      - System and Information Integrity
@@ -2185,11 +2224,11 @@ SIMP SCTM Management Controls
    * - RA-5(1)
      - Vulnerability Scanning (Control Enhancement)
      - Risk Assessment
-     - SCAP-Security-Guide is the two primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
+     - SCAP-Security-Guide is the primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
    * - RA-5(2)
      - Vulnerability Scanning (Control Enhancement)
      - Risk Assessment
-     - SCAP-Security-Guide is the two primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
+     - SCAP-Security-Guide is the primary tool used to check for suspected configuration errors. Puppet also continues to protect clients against unwanted changes.
    * - RA-5(3)
      - Vulnerability Scanning (Control Enhancement)
      - Risk Assessment


### PR DESCRIPTION
The code has been updated to both properly build the PDF and to fail if
the PDF was not built properly.

It turns out that a 0 length PDF was being output and we were not
catching this anomaly properly.

SIMP-993 #close #comment Fixed for 4.2.X