### PR TITLE
(SIMP-460) Update to look at simp-core

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,7 @@ Known OS Compatibility
 
 changelog_urls = []
 for version_target in github_version_targets:
-    changelog_urls.append('/'.join([github_base, 'simp-doc', version_target, changelog_name]))
+    changelog_urls.append('/'.join([github_base, 'simp-core', version_target, changelog_name]))
 
 changelog_stub = """
 Changelog Stub


### PR DESCRIPTION
The scripts should try to pull from simp-core instead of simp-doc for
the Changelog content from now on.

SIMP-460 #comment Update to move to the proper remote repos.