### PR TITLE
(SIMP-1308) Update local user documentation

### DIFF
--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -131,6 +131,10 @@ mv pdf/SIMP_Documentation.pdf pdf/SIMP-%{version}-%{release}.pdf
 # Post uninstall stuff
 
 %changelog
+* Thu Aug 04 2016 Nick Markowski <nmarkowski@keywcorp.com>
+- Fixed syntax errors in Local User creation docs.
+- Added SSSD Local domain/user creation docs.
+
 * Fri Jun 10 2016 Nick Miller <nick.miller@onyxpoint.com>
 - Added FAQ entries for disabling DHCP and named
 

--- a/docs/user_guide/User_Management.rst
+++ b/docs/user_guide/User_Management.rst
@@ -10,3 +10,4 @@ This chapter explains how to manage users in the default SIMP environment.
 
   User_Management/LDAP
   User_Management/Local_Users
+  User_Management/SSSD

--- a/docs/user_guide/User_Management/Local_Users.rst
+++ b/docs/user_guide/User_Management/Local_Users.rst
@@ -26,7 +26,7 @@ Service Account
 
     $_svc_account_user           = 'svcuser'
     $_svc_account_group          = 'svcgroup'
-    $_svc_account_id             = '1777',
+    $_svc_account_id             = '1777'
     $_svc_account_homedir        = "/var/local/${_svc_account_user}"
 
     # Since this is a service account, automatically generate an SSH key for
@@ -80,7 +80,7 @@ Service Account
     }
 
     sudo::user_specification { $_svc_account_user:
-      user_list => ["(${_svc_account_group})"],
+      user_list => ["${_svc_account_user}"],
       host_list => [$::fqdn],
       runas     => 'root',
       cmnd      => ['/bin/cat /var/log/app.log'],
@@ -89,7 +89,7 @@ Service Account
 
     # Allow this service account from everywhere
     pam::access::manage { "Allow ${_svc_account_user}":
-      users   => ${_svc_account_user},
+      users   => $_svc_account_user,
       origins => ['ALL']
     }
   }
@@ -104,7 +104,7 @@ Local User Account
 
     $_local_account_user           = 'localuser'
     $_local_account_group          = 'localgroup'
-    $_local_account_id             = '1778',
+    $_local_account_id             = '1778'
 
     # You'll probably want this in /home unless you're using NFS
     $_local_account_homedir        = "/home/${_local_account_user}"
@@ -126,15 +126,18 @@ Local User Account
       shell      => '/bin/bash'
     }
 
+    # If you want your local user to have a password (no key),
+    # omit this block and manually assign a password to the user
+    # after creation (passwd <user>)
     file { "/etc/ssh/local_keys/${_local_account_user}":
       owner  => 'root',
       group  => $_local_account_group,
       mode   => '0644',
-      source => "puppet:///site/ssh_autokeys/${_local_account_user}.pub"
+      source => $_local_account_ssh_public_key
     }
 
     sudo::user_specification { $_local_account_user:
-      user_list => ["(${_local_account_group})"],
+      user_list => ["${_local_account_user}"],
       host_list => [$::fqdn],
       runas     => 'root',
       cmnd      => ['/bin/cat /var/log/app.log'],
@@ -143,7 +146,7 @@ Local User Account
 
     # Allow this account from everywhere
     pam::access::manage { "Allow ${_local_account_user}":
-      users   => ${_local_account_user},
+      users   => $_local_account_user,
       origins => ['ALL']
     }
   }

--- a/docs/user_guide/User_Management/SSSD.rst
+++ b/docs/user_guide/User_Management/SSSD.rst
@@ -1,0 +1,98 @@
+.. _sssd_local_user_management:
+
+Managing SSSD LOCAL Domain And Users
+====================================
+
+Though the SIMP team **highly recommends** using :ref:`LDAP <Managing LDAP Users>`
+to centrally manage your users, you may wish to create users within the SSSD
+LOCAL provider domain.
+
+This section walks you through doing this in a way that is compatible with SIMP.
+
+The following examples assume that you are using the *site* module to set up
+your users. The examples may easily be extrapolated into defined types if you
+wish but are presented as classes for simplicity.
+
+SSSD LOCAL Domain
+-----------------
+
+Set up a LOCAL domain in SSSD. If one already exists in /etc/sssd/sssd.conf,
+you can skip this step.
+
+.. code-block:: ruby
+
+  class site::sssd_local {
+
+    sssd::provider::local { 'LOCAL' }
+
+    sssd::domain { 'LOCAL':
+      description   => 'Default Local Domain',
+      id_provider   => 'local',
+      auth_provider => 'local'
+    }
+  }
+
+In hiera, you will need to add the LOCAL sssd domain to sssd::domains if it
+does not already exist.  Include site::sssd_local, and set 'local' as the
+domain id_provider.
+
+.. code-block:: ruby
+
+  sssd::domains:
+    - 'LOCAL'
+  sssd::domain::id_provider: 'local'
+  classes:
+    - 'site::sssd_local'
+
+Run puppet.  A LOCAL domain should be created and referenced in /etc/sssd/sssd.conf.
+The sssd service should be running.
+
+Adding an SSSD Local User
+-------------------------
+
+Create a local user, using sss_useradd.  Man sss_useradd for more options.
+
+.. code-block:: ruby
+
+  sss_useradd <user> -h </path/to/home/dir> -u <uid> -m -k /etc/skell
+
+There is a bug in CentOS 6 which does not allow sssd to modify /etc/passwd.
+Do so manually:
+
+.. code-block:: ruby
+
+  vipw
+  <user>:x:<uid>:<gid>::</path/to/home/dir>:/bin/bash
+
+Next, set the user's password.  As root, run:
+
+.. code-block:: ruby
+
+  passwd <user>
+
+Giving The User Access
+----------------------
+
+.. code-block:: ruby
+
+  pam::access::manage { '<user> access':
+    permission => '+',
+    users      => '<user>',
+    origins    => ['ALL'],
+    order      => '1000'
+  }
+
+  sudo::user_specification { '<user> privs':
+    user_list => ["<user>"],
+    host_list => [$::fqdn],
+    runas     => 'root',
+    cmnd      => ['/bin/cat /var/log/app.log'],
+    passwd    => false
+  }
+
+You're done! You should be able to id <user>, su - <user>, and run commands
+allowed by sudo rules.
+
+Test authentication by ssh-ing as the <user> onto the host machine, with the
+password specified after user creation.  If you want to set up an ssh key,
+you may want to follow the relevant `GitHub documentation <https://help.github.com/articles/generating-ssh-keys/>`__.


### PR DESCRIPTION
SIMP-1308 #close Fixed syntax errors in Local User manifest.
SIMP-1307 #close Added docs for managing SSSD LOCAL domain
and creating users via SSSD.
