### PR TITLE
(SIMP-1408) Don't enable krb5 with autofs (yet!)

### DIFF
--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -131,6 +131,9 @@ mv pdf/SIMP_Documentation.pdf pdf/SIMP-%{version}-%{release}.pdf
 # Post uninstall stuff
 
 %changelog
+* Thu Aug 25 2016 Nick Markowski <nmarkowski@keywcorp.com>
+- Added warning not to enable krb5 with autofs.
+
 * Thu Aug 04 2016 Nick Markowski <nmarkowski@keywcorp.com>
 - Fixed syntax errors in Local User creation docs.
 - Added SSSD Local domain/user creation docs.

--- a/docs/user_guide/HOWTO/NFS.rst
+++ b/docs/user_guide/HOWTO/NFS.rst
@@ -166,6 +166,13 @@ If you wish to encrypt your NFS data using stunnel, set the following in
 Enabling krb5
 -------------
 
+.. warning::
+
+  This functionality is incomplete. See ticket SIMP-1400 in our
+  `JIRA Bug Tracking`_ . Until that ticket is resolved, it is
+  HIGHLY recommended you continue to use stunnel for encrypted
+  nfs traffic.
+
 default.yaml
 ^^^^^^^^^^^^
 
@@ -207,3 +214,6 @@ Client
 
   classes:
     - 'simp::nfs::home_client'
+
+
+.. _JIRA Bug Tracking: https://simp-project.atlassian.net/


### PR DESCRIPTION
Until SIMP-1400 is completed, a warning will remain in place not
to enable autofs with krb5.

SIMP-1408 #comment simp-doc warning complete