### PR TITLE
(SIMP-1419) Restored and updated the SecCONOP

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,7 +1,10 @@
 Glossary of Terms
 =================
 
-.. note:: Many terms here have been reproduced from various locations across the Internet and are governed by the licenses surrounding the source material. Please see the reference links for specifics on usage and reproducibility.
+.. note::
+  Many terms here have been reproduced from various locations across the
+  Internet and are governed by the licenses surrounding the source material.
+  Please see the reference links for specifics on usage and reproducibility.
 
 .. glossary::
    :sorted:
@@ -66,6 +69,18 @@ Glossary of Terms
 
       Source: `Wikipedia: Central Processing Unit <https://en.wikipedia.org/wiki/Central_processing_unit>`__
 
+   DAC
+   Discretionary Access Control
+      A type of access control defined by the Trusted Computer System
+      Evaluation Criteria[1] "as a means of restricting access to objects
+      based on the identity of subjects and/or groups to which they belong.
+      The controls are discretionary in the sense that a subject with a
+      certain access permission is capable of passing that permission (perhaps
+      indirectly) on to any other subject (unless restrained by mandatory
+      access control)".
+
+      Source: `Wikipedia: Discretionary access control <https://en.wikipedia.org/wiki/Discretionary_access_control>`__
+
    DNS
    Domain Name System
       A database system that translates a computer's fully qualified domain
@@ -75,6 +90,15 @@ Glossary of Terms
    Dynamic Host Configuration Protocol
       A network protocol that enables a server to automatically assign an IP
       address to a computer.
+
+   DoS
+   Denial of Service
+   Denial of Service Attack
+      An attempt to make a machine or network resource unavailable to its
+      intended users, such as to temporarily or indefinitely interrupt or
+      suspend services of a host connected to the Internet.
+
+      Source: `Wikipedia: Denial-of-service attack <https://en.wikipedia.org/wiki/Denial-of-service_attack>__
 
    EL
    Enterprise Linux
@@ -113,9 +137,9 @@ Glossary of Terms
    FIPS
    Federal Information Processing Standard
       Federal Information Processing Standards (FIPS) Publications are
-      standards issued by NIST after approval by the Secretary of
-      Commerce pursuant to the Federal Information Security Management
-      Act (FISMA)
+      standards issued by :term:`NIST` after approval by the Secretary of
+      Commerce pursuant to the Federal Information Security Management Act
+      (FISMA)
 
       The particular standard of note in SIMP is `FIPS 140-2 <http://csrc.nist.gov/publications/fips/fips140-2/fips1402.pdf>`__
 
@@ -197,11 +221,29 @@ Glossary of Terms
       information such as names, addresses, email, phone numbers, and other
       information from an online directory.
 
+   LDIF
+   Lightweight Directory Interchange Format
+     A standard plain text data interchange format for representing
+     :term:`LDAP` (Lightweight Directory Access Protocol) directory content and
+     update requests. LDIF conveys directory content as a set of records, one
+     record for each object (or entry). It also represents update requests,
+     such as Add, Modify, Delete, and Rename, as a set of records, one record
+     for each update request.
+
+      Source: `Wikipedia: LDAP Data Interchange Format <https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format>`__
+
    LUKS
    Linux Unified Key Setup
       The standard for Linux hard disk encryption.
 
       See: `The LUKS Homepage <https://gitlab.com/cryptsetup/cryptsetup/blob/master/README.md>`__
+
+   Mandatory Access Control
+      A type of access control by which the operating system constrains the
+      ability of a subject or initiator to access or generally perform some
+      sort of operation on an object or target.
+
+      Source: `Wikipedia: Mandatory access control <https://en.wikipedia.org/wiki/Mandatory_access_control>`__
 
    MAC
    MAC Address
@@ -217,11 +259,42 @@ Glossary of Terms
       The process of modifying IP address information in IP packet headers
       while in transit across a traffic routing device.
 
+   NIST
+   National Institute of Standards and Technology
+      The National Institute of Standards and Technology (NIST) was founded in
+      1901 and now part of the U.S. Department of Commerce. NIST is one of the
+      nation's oldest physical science laboratories.
+
+      Source: `NIST - About NIST <https://www2.nist.gov/about-nist>`__
+
+   NIST SP
+   NIST Special Publication
+      A set of publications that provide computer/cyber/information security
+      and guidelines, recommendations, and reference materials.
+
+      See: `NIST Special Publications <http://csrc.nist.gov/publications/PubsSPs.html>`__
+
+   NIST 800-53
+   NIST SP 800-53
+   NIST Special Publication 800-53
+      Security and Privacy Controls for Federal Information Systems and
+      Organizations
+
+      See: `SP 800-53 <http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf>`__
+
    NFS
    Network File System
       A distributed file system protocol that allows a user on a client
       computer to access files over a network in a manner similar to how local
       storage is accessed.
+
+   OS
+   Operating System
+      System software that manages computer hardware and software resources and
+      provides common services for computer programs. All computer programs,
+      excluding firmware, require an operating system to function.
+
+      Source: `Wikipedia: Operating system <https://en.wikipedia.org/wiki/Operating_system>`__
 
    PSSH
    Parallel Secure Shell
@@ -344,6 +417,13 @@ Glossary of Terms
 
       See also :term:`TLS`.
 
+   SELinux
+      A Linux kernel security module that provides a mechanism for supporting
+      access control security policies, including United States Department of
+      Defense–style mandatory access controls (MAC).
+
+      Source: `Wikipedia: Security-Enhanced Linux <https://en.wikipedia.org/wiki/Security-Enhanced_Linux>`__
+
    SIMP
    System Integrity Management Platform
       A security framework that sits on top of :term:`RHEL` or :term:`CentOS`.
@@ -361,6 +441,12 @@ Glossary of Terms
       An application that acts as an echo logger to enhance the auditing of
       privileged activities at the command line of the operating system.
       Utilities are available for playing back sudosh sessions in real time.
+
+   SYN cookies
+   syncookies
+      A technique used to resist SYN flood attacks.
+
+      Source: `Wikipedia: SYN cookies <https://en.wikipedia.org/wiki/SYN_cookies>`__
 
    TLS
    Transport Layer Security

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Contents:
   Changelog <dynamic/Changelog>
   Installation Guide <installation_guide/index>
   User Guide <user_guide/index>
+  Security Concept of Operations <security_conop/index>
   Security Control Mapping <security_mapping/index>
   license
   help

--- a/docs/security_conop/Introduction.rst
+++ b/docs/security_conop/Introduction.rst
@@ -1,0 +1,38 @@
+Introduction
+============
+
+This manual describes the security concepts of the SIMP system. The system was
+originally designed to meet a specific set of technical security controls using
+industry best practices and has been modified recently to meet as many of the
+security controls provided by the National Institute of Standards and
+Technology's (:term:`NIST`) special publication `800-53`_ as possible.
+
+This manual outlines three categories of security:
+
+*  **Technical Architecture**: discusses the technical approaches to securing
+   the system
+
+*  **Operational Security**: discusses the security of SIMP in an operational
+   setting
+
+*  **Information System Management**: discusses how SIMP helps achieve security
+   in terms of system management
+
+A brief discussion of how the SIMP system helps achieve categories of controls
+is provided; additional technical details regarding each control can be found
+in the :ref:`SIMP_Security_Control_Mapping`.
+
+When possible, the NIST security control identifier will be found at the end of
+a concept to provide the reader with a reference to the specific control that
+is being discussed. The identifier is written as [AB-X(Y)], where A is the
+control family, X is the control section, and Y is the control enhancement.
+
+.. note::
+  At present, this document will **not** be mapped to any additional standards
+  since there are available mappings of the 800-53 to various other security
+  frameworks.
+
+  If you believe that we are missing anything in particular, please `file a bug`_!
+
+.. _800-53: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+.. _file a bug: http://simp-project.atlassian.net

--- a/docs/security_conop/Operational_Security.rst
+++ b/docs/security_conop/Operational_Security.rst
@@ -1,0 +1,161 @@
+Operational Security
+====================
+
+This chapter contains SIMP security concepts that are related to the
+operational security controls in :term:`NIST 800-53`.
+
+Configuration Management
+------------------------
+
+This section describes the management of various configurations within SIMP.
+
+Baseline Configurations
+~~~~~~~~~~~~~~~~~~~~~~~
+
+SIMP baselines include configuration settings and Puppet modules.  Currently,
+baselines are maintained for both Red Hat/CentOS 6.x, and Red Hat/CentOS 7.x.
+Each configuration item that is managed by a Puppet module has an RPM installed
+on the Puppet Master in the form of ``pupmod-name-x.x.x-x``. This process
+allows for one main SIMP baseline to be maintained and modules to be upgraded
+easily. An overall SIMP RPM is also installed on the Puppet Master, which
+denotes the version number of SIMP that is installed.
+[:ref:`CM-2`, :ref:`CM-2 (2)`, :ref:`CM-2 (3)`, :ref:`CM-6`]
+
+SIMP installs a minimal set of :term:`RPMs`, which can be found in the
+kickstart files on the ISO. RPMs, services, and IPTables rules all use a
+whitelist stance for allowing access or installation.
+[:ref:`CM-2 (5)`]
+
+* Additional RPMs must be installed by each implementation.
+* Services must be declared explicitly or they will be disabled by Puppet
+* IPTables rules must allow a service explicitly.
+
+Managing Configuration Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configuration change approvals are managed by each implementation; SIMP only
+provides the mechanisms to apply changes on clients. A combination of Puppet,
+rsync, and :term:`YUM` is used to apply those changes across any number of
+target Puppet clients. All changes made are audited with ``auditd`` or are
+logged to via ``syslog``.
+[:ref:`CM-3a.`, :ref:`CM-3 (3)`]
+
+Linux systems are made up of hundreds of configuration files that can contain
+numerous of settings. SIMP does not make an attempt to manage all of the
+settings in every file. Instead, critical operating system files or files that
+need to be controlled centrally are managed. Implementations can manage
+additional files if they are deemed necessary.
+[:ref:`CM-6`]
+
+Security Verification and Flaw Remediation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SIMP cannot detect flaws automatically; each implementation is responsible for
+tracking flaws. However, SIMP provides a way for flaws to be fixed across all
+clients. One or all of the following can help automate flaw remediation
+[:ref:`CM-6`, :ref:`SI-2`, :ref:`SI-2 (1)`, :ref:`SI-2 (4)`]:
+
+*  **Puppet:**
+
+   * Apply a configuration change to files that are managed by Puppet.
+
+*  **rsync:**
+
+   * Use this mechanism to deliver a file to a client. This can be used with or
+     without Puppet to synchronize files.
+
+*  **YUM:**
+
+   * Update packages nightly with YUM. Placing an updated package in YUM and
+     running a YUM update manually, or allowing time for the cron job to run,
+     will ensure packages on all clients are updated.  Otherwise, a cron job
+     will perform a daily update of packages with YUM.
+
+*  **MCollective:**
+
+   * Allow users to execute **specific** commands across large numbers of nodes
+     in an auditable, distributed, and scalable, fashion.
+
+The extent of security verification that is performed currently is based on
+changes to files that Puppet or the Advanced Intrusion Detection Environment
+(AIDE) provides. There are also Security Content Automation Protocol (SCAP)
+profiles available from the SCAP-Security-Guide project that check security
+configuration settings.
+[:ref:`SI-6`]
+
+Malicious Code Protection
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For most environments, SIMP will use ClamAV to protect against malicious code.
+Rsync is used to push out new definitions, which should be updated by the local
+administrator regularly. SIMP also comes with a ``mcafee::uvscan`` module that
+manages an installation of uvscan, if it is preferred. The module can configure
+``.dat`` file updates to occur over ``rsync``.
+
+Both the ClamAV and McAfee modules provide a method to run a scan via cron on a
+customer scheduled basis.
+[:ref:`SI-3`]
+
+SIMP also comes with the ``chkrootkit`` tool to check for *rootkits*. The tool
+runs as a cron job and places its output into syslog.
+[:ref:`SI-3`]
+
+Software and Information Integrity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unauthorized changes to a local client can be detected by Puppet or AIDE (for
+any file managed by Puppet). In the event that a managed file is changed
+locally, Puppet will revert the file back to its original state.  It is
+important to note that this is a function of Puppet and is intended to be more
+of a configuration management feature rather than a security feature. If a
+Puppet client has been compromised, the Puppet Master may not have the ability
+to retake control over that client.  However, the Puppet Master can configure
+all other nodes to deny traffic from the compromised node if they are
+configured by the administrator to do so. There are additional configuration
+files that are checked by AIDE, which is triggered by a cron job. AIDE logs any
+detected file changes in syslog. Each implementation may add additional files
+that are managed by Puppet or watched by AIDE. The AIDE baseline database is
+updated periodically to handle the installation and updating of system RPMs and
+reduce false positives.
+[:ref:`SI-7`, :ref:`SI-7 (1)`, :ref:`SI-7 (2)`, :ref:`SI-7 (3)`]
+
+Remote Maintenance
+------------------
+
+Remote maintenance can be performed on SIMP using :term:`SSH`. Local
+maintenance can be performed at the console or via serial port (if available).
+SSH sessions are tracked and logged using the security features built into
+SIMP. Console access requires someone to have access to the physical (or
+virtual) console along with the ``root`` password. Auditing of those actions
+also occurs in accordance with the configured audit policy. It is up to the
+implementer to decide how to distribute authentication information for remote
+maintenance.
+[:ref:`MA-4`, :ref:`MA-4 (1)`, :ref:`MA-6`]
+
+Incident Response
+-----------------
+
+While Puppet is not intended to be a security product primarily, its features
+help provide security functionality such as dynamic reconfigurations and
+wide-scale consistent mitigation application. If an implementation chooses,
+they can leverage Puppet's ability to reconfigure systems as part of incident
+response.
+
+SIMP also delivers an MCollective infrastructure which can be used to rapidly
+query for system state or apply hotfixes in a scalable manner.
+[:ref:`IR-1`]
+
+Contingency Planning
+--------------------
+
+SIMP does not provide any direct support for contingency planning. Some of the
+mechanisms provided by SIMP might be used to support an implementation's
+contingency plan.
+
+System Backup
+-------------
+
+SIMP comes with a module called ``backuppc``. This module provides a base
+configuration of the `BackupPC <http://backuppc.sourceforge.net/>`__ software
+and allows Puppet servers and clients to perform backups.
+[:ref:`CP-10 (6)`]

--- a/docs/security_conop/System_Management.rst
+++ b/docs/security_conop/System_Management.rst
@@ -1,0 +1,70 @@
+Information System Management
+=============================
+
+This chapter contains SIMP security concepts that are related to the management
+security controls in :term:`NIST 800-53`.
+
+Risk Assessment
+---------------
+
+This section describes the process of identifying risks within a system.
+
+SIMP Self Risk Assessment
+-------------------------
+
+Risk can be found in any system. The SIMP team is constantly evaluating the
+system and the settings to minimize inherit risk. Most risks can be mitigated
+by processes and procedures at the implementation level. The following table
+describes the known areas in SIMP.
+[:ref:`RA-1`]
+
+.. list-table::
+  :header-rows: 1
+
+  - * Risk
+    * Possible Mitigations
+  - * **Disabling Puppet**: This can cause the clients to be out of sync with
+      the Puppet Master.
+    * SIMP attempts to force a break on any locks and restart Puppet on all
+      clients after a time of 4*runinterval (30 minutes by default).
+      Implementations should ensure that further steps have not been taken to
+      disable Puppet and should monitor their logs. Administrators can use the
+      puppetlast command on the Puppet Master to detect servers that have not
+      checked in within a reasonable time period.
+  - * **Out of Date Patches**: SIMP can be built with the RPMs from CentOS or
+      Red Hat. Those RPMs should be assumed out of date at the time a system is
+      initially installed (if using the SIMP DVD).
+    * Implementations should obtain the latest RPMs and apply them in a
+      reasonable manner. All SIMP systems will, by default, attempt to update
+      all packages using YUM nightly. Therefore, having an updated repository
+      will ensure that the systems are updated on a regular basis.
+  - * **Poor Account Management**: SIMP security access control is based on
+      users being created and managed over time. Giving shell access to
+      unnecessary users allows them the opportunity to escalate privileges.
+    * Use the default :term:`LDIF`s and local user modules to ensure that
+      account settings remain restrictive. Ensure the system has policies and
+      procedures in place to manage accounts. Finally, ensure that users are in
+      appropriate groups with limited privileges.
+
+Table: SIMP Risk
+
+Vulnerability Scanning
+----------------------
+
+The SIMP development and security team performs regular vulnerability scanning
+of the product using commercial and open source tools. Results and mitigations
+for findings from those tools can be provided upon request.
+[:ref:`CA-2`, :ref:`RA-5`]
+
+Security Assessment and Authorization
+-------------------------------------
+
+Assessment and authorization varies by implementation. Implementations are
+encouraged to use documentation artifacts provided by the SIMP team to assist
+with assessment and authorization.
+[:ref:`CA-2`]
+
+.. NOTE::
+  Should users find issues with internal assessments, the SIMP team highly
+  encourages them to submit a bug report using our `Bug Tracker
+  <https://simp-project.atlassian.net>`__

--- a/docs/security_conop/Technical_Security.rst
+++ b/docs/security_conop/Technical_Security.rst
@@ -1,0 +1,532 @@
+Technical Security
+==================
+
+This chapter contains SIMP security concepts that are related to the technical
+security controls described in :term:`NIST 800-53`.
+
+Identification and Authentication
+---------------------------------
+
+This section addresses the identification and authentication of users and
+devices.
+
+User Identification and Authentication
+--------------------------------------
+
+Identification and authentication of system and service users can occur at
+either the :term:`Operating System` level or globally in the SIMP architecture.
+While local accounts and groups can be created manually, the SIMP team suggests
+adding users via the ``/etc/puppet/localusers`` file or by using the native
+Puppet user and group types. System users can authenticate their access using
+Secure Shell (SSH) keys or passwords. For more centralized control, identify
+and authenticate users by using the Lightweight Directory Access Protocol
+(:term:`LDAP`).
+[:ref:`IA-2`]
+
+The SIMP team recommends using :term:`LDAP` as the primary source for user
+management and provides a functional default OpenLDAP configuration for this
+purpose. :term:`LDAP` and Pluggable Authentication Modules (:term:`PAM`) work
+together closely and, with the default SIMP configuration, the PAM settings are
+enforced on top of the LDAP settings for two layers of control. Due to this
+partnership, items such as account lockouts may need to be reset on both the
+local system and the LDAP server. If the suggested settings in the
+SIMP-provided default LDAP Directory Interchange Formats (:term:`LDIF`) are not
+used, implementations must ensure that security is maintained through manual
+procedures. Use of group accounts for users is strongly discouraged. System
+services may need to have accounts, but all of these should be managed by
+Puppet using the user and group native types.
+[:ref:`IA-2 (5)`].
+
+Device Identification and Authentication
+----------------------------------------
+
+Devices are identified by a Media Access Control (:term:`MAC`) address prior to
+receiving an :term:`IP` address via the Dynamic Host Configuration Protocol
+(:term:`DHCP`). In the default SIMP architecture, :term:`IP` addresses are
+fixed mappings to their associated :term:`MAC` address (i.e., not assigned
+dynamically).  There is no authentication for the binding of :term:`MAC`
+addresses to :term:`IP` addresses due to the nature of the :term:`DHCP`
+protocol.
+
+Device authentication occurs through the mapping of the MAC to the IP through
+the internally controlled DHCP and the mapping of the IP to the host name
+through the internally controlled Domain Name System (DNS) service for each
+individual Puppet client. After kickstart, each client system generates an
+internal cryptographic identifier and communicates that information with the
+Puppet server to be approved by an administrator at a later time. All further
+communication between the Puppet server and the clients over the Puppet
+protocol is encrypted subsequently and authenticated with this identifier.
+Automatic approval can be set up in tightly controlled environments; however,
+this option is not suggested for open environments.
+[:ref:`IA-3`, :ref:`IA-3 (3)`]
+
+Identifier Management
+---------------------
+
+Managing user identifiers (also known as user names) involves administrative
+procedures that are unique for each implementation.  Disabling unused local
+accounts is the only control that SIMP can enforce technologically. In this
+case, if an account has an expired password that has not been changed 35 days
+after expiration, the account will be disabled. If a user does not have a
+password (e.g., he or she only authenticates with SSH keys), then there is no
+inherent technological mechanism for enforcement due to the nature of the
+software.
+[:ref:`IA-4e.`]
+
+Authenticator Management
+------------------------
+
+Authenticators for users are passwords and/or :term:`SSH` keys; the management
+of each is implementation specific. SSH keys do not expire; therefore,
+implementations must provide a procedure for removing invalid keys. Removing
+public keys from LDAP is one practical solution.
+
+When using passwords, local and LDAP passwords provided for users should be set
+to change at first login. This is the default in the SIMP-provided LDIFs. Once
+a user attempts to change a password, the settings in PAM and LDAP enforce
+complexity requirements.
+
+By default, SIMP requires the following password complexity:
+
+  * 14 Characters
+  * 1 Upper Case Letter
+  * 1 Lower Case Letter
+  * 1 Number
+  * 1 Special Character
+  * No more than 3 consecutive characters from each category
+
+[:ref:`IA-5`, :ref:`IA-5 (1)`, :ref:`IA-5 (4)`]
+
+Password aging and history is enforced through a combination of :term:`PAM` and
+:term:`LDAP`. By default, the previous **24** passwords cannot be reused.
+
+[:ref:`IA-5 (1)(e)`]
+
+There are a number of default passwords in SIMP that are required for
+installation. Each implementation requires the user to change the default
+passwords and protect the new passwords. In addition, there are embedded
+passwords within the SIMP system that are used due to a lack of
+software-supported alternatives.
+
+Please see the :ref:`simp-user-guide` for additional information.
+
+Access Control
+--------------
+
+This section describes the various levels of access control, including account
+management, access enforcement, information flow enforcement, separation of
+duties, least privilege, session controls, permitted actions without
+identification and authentication, security attributes, and remote access.
+
+Account Management
+------------------
+
+Account management procedures should be created and maintained for each
+implementation of SIMP. The procedures should include the information listed in
+:term:`NIST 800-53` control :ref:`AC-2`. SIMP has the mechanisms in place to
+enforce most account management policies. The mechanisms for account management
+have several default settings including:
+
+*  Central account management using OpenLDAP. [:ref:`AC-2 (1)`]
+*  Password expiration.
+
+   * Local accounts expire 35 days after password expiration. [:ref:`AC-2 (3)`]
+   * :term:`LDAP` accounts do not expire automatically due to inactivity;
+     implementations should audit LDAP accounts regularly.
+
+*  Auditing of administrative actions to capture local account creation and
+   modifications to :term:`LDAP` accounts is done via the
+   ``/var/log/slapd_audit.log`` file and ``/var/log/audit/audit.log`` for local
+   accounts. [:ref:`AC-2 (4)`]
+*  Shell sessions timeout after **15 minutes** of inactivity. [:ref:`AC-2 (5)`]
+
+   * This can be circumvented by running a command that opens an endless pipe
+     such as ``/bin/cat``. However, this command cannot be enforced more
+     heavily due to the high likelihood of breaking system applications. If the
+     optional gnome module is used, the GNOME screen saver will lock the screen
+     after **15 minutes** of inactivity.
+
+*  Assignment of users into groups locally or centrally via LDAP. [:ref:`AC-2 (7)`]
+
+   * By default, SIMP will have an administrators groups that has the ability
+     to run ``sudosh``. Implementations should further define administrators or
+     user groups and limit them with the Puppet ``sudo`` class.
+
+Access Enforcement
+------------------
+
+SIMP uses the implementation of Discretionary Access Control (:term:`DAC`) that
+is native to Linux. Specific file permissions have been assigned based on
+published security guidance for Red Hat, CentOS, and UNIX.
+
+Default permissions on files created by users are enforced with user file
+access mask settings (using the ``umask`` command) that allow only the owner to
+read and write to the file. Implementations may further extend the access
+control in UNIX by restricting access to application files or using the file
+Access Control List (:term:`ACL`) commands ``getfacl`` and ``setacl``. Users of
+SIMP should not change file permissions on operating system files as it may
+decrease the overall security of the system. If a group needs access to a
+particular file or directory, use the ``setfacl`` command to allow the
+necessary access without lessening the permissions on the system.
+[:ref:`AC-3`]
+
+.. _Flow_Enforcement:
+
+Information Flow Enforcement
+----------------------------
+
+:term:`IPTables` on each SIMP system is controlled by the IPTables Puppet
+module. When developing a new module, the IPTables rules needed for an
+application should be included with the module by calling the appropriate
+methods from the IPTables module. The end result should be a running IPTables
+rule set that includes the default SIMP rules and any rules needed for
+applications. The default communications allowed are included in
+:ref:`default_server_ports` and :ref:`default_client_ports`.
+[:ref:`AC-4`]
+
+.. _default_server_ports:
+
+Default Server Ports
+~~~~~~~~~~~~~~~~~~~~
+
+=========== ========= ========== ========= ======= =======================================================================
+Application Direction Protocol   Transport Ports   Comment
+=========== ========= ========== ========= ======= =======================================================================
+Puppet      Localhost HTTP       TCP       8140    The port upon which the Puppet master listens for client connections via Apache
+Puppet CA   In        HTTPS      TCP       8141    This is used to ensure that Apache can verify all certificates from external systems properly prior to allowing access to Puppet.
+Apache/YUM  In        HTTP       TCP       80      This is used for YUM and is unencrypted, since YUM will not work otherwise.
+DHCPD       In        DHCP/BOOTP TCP/UDP   546,547 DHCP pooling is disabled by default and should only be used if the implementation requires the use of this protocol.
+TFTP        In        TFTP       TCP/UDP   69      This is used for kickstart. It could also be used to update network devices. TFTP does not support encryption.
+rsyslog     Out       syslog     TCP/UDP   6514    This is encrypted when communicating with a SIMP syslog server (not installed by default).
+named       In/Out    DNS        TCP/UDP   53      Inbound connections happen to the locally managed hosts. Outbound connections happen to other domains per the normal operations of DNS.
+NTPD        Out       NTP        TCP/UDP   123     Only connects to an external time source by default.
+SSHD        In        SSH        TCP       22      SSH is always allowed from any source IP by default.
+stunnel     In        TLS        TCP       8730    Stunnel is a protected connection for rsyncing configuration files to Puppet clients.
+rsync       Localhost RSYNC      TCP       873     This accepts connections to the localhost and forwards through Stunnel.
+LDAP        In        LDAP       TCP       389     Connections are protected by bi-directional, authenticated encryption.
+LDAPS       In        LDAPS      TCP       636     Used for LDAP over SSL.
+=========== ========= ========== ========= ======= =======================================================================
+
+.. _default_client_ports:
+
+Default Client Ports
+~~~~~~~~~~~~~~~~~~~~
+
+=========== ========= ========== ========= ======= =======================================================================
+Application Direction Protocol   Transport Ports   Comment
+=========== ========= ========== ========= ======= =======================================================================
+Puppet      Out       HTTPS      TCP       8140    Communications to the Puppet server.
+rsyslog     Out       syslog     TCP/UDP   6514    This is encrypted when communicating with a SIMP syslog server.
+DNS Client  Out       DNS        TCP/UDP   53      Normal name resolution.
+NTPD        Out       NTP        TCP/UDP   123     Only connects to an external time source by default.
+SSHD        In        SSH        TCP       22      SSH is allowed from any source IP by default.
+LDAP        Out       LDAP       TCP       389     Connections are protected by bi-directional authenticated encryption.
+=========== ========= ========== ========= ======= =======================================================================
+
+Separation of Duties
+--------------------
+
+SIMP enforces separation of duties using account groups. Groups are created
+with each implementation to separate roles or duties properly.  The SIMP team
+recommends that this management be done using the **posixGroup** object in
+:term:`LDAP` for full :term:`OS` support.
+[:ref:`AC-5`]
+
+Least Privilege
+---------------
+
+SIMP does not allow ``root`` to directly :term:`SSH` into a system. Direct
+access to the ``root`` user must occur via a console (or at a virtual instance
+of the physical console) to log on. Otherwise, users must log on as themselves
+and perform privileged commands using ``sudo`` or ``sudosh``.
+[:ref:`AC-6`]
+
+:term:`NIST 800-53` least privilege security controls give people access to
+objects only as needed. SIMP provides only the needed software, services, and
+ports to allow the system to be functional and scalable.  The system then
+relies on a given implementation to perform proper account management and user
+role assignments.
+[:ref:`AC-6`]
+
+Session Controls
+----------------
+
+SIMP provides a number of security features for sessions. These features
+include:
+
+*  Accounts are locked after **five** invalid log on attempts over a **15
+   minute** period. The account is then locked for **15 minutes**. No
+   administrator action is required to unlock an account. [:ref:`AC-7`]
+
+*  System banners are presented to a user both before and after logging on. The
+   default banner should be customized for each implementation. [:ref:`AC-8`]
+
+*  After a successful log on, the date, time, and source of the last log on is
+   presented to the user. The number of failed log on attempts since the last
+   log on is also provided. [:ref:`AC-9` and :ref:`AC-9 (1)`]
+
+*  A limit of **10** concurrent SSH sessions are allowed per user. This can be
+   further limited if an implementation decides it is set too high.  Given the
+   way SSH is used in most operational settings, this default value is
+   reasonable.  [:ref:`AC-10`]
+
+*  Session lock only applies if the ``windowmanager::gnome`` module is used.
+   Sessions lock automatically after **15 minutes** of inactivity.  Users must
+   authenticate their access with valid credentials to reestablish a session.
+   [:ref:`AC-11`]
+
+Permitted Actions Without Identification and Authentication
+-----------------------------------------------------------
+
+SIMP has a number of applications that do not require both identification and
+authentication. These services are listed below along with an explanation of
+why these aspects are not required.  Implementations should include any
+additional services that do require identification and/or authentication.
+[:ref:`AC-14`]
+
+=================== ========================================
+Service/Application Rationale
+=================== ========================================
+TFTP                TFTP is a simple file transfer application that, in the SIMP environment, does not allow for writing to the files being accessed. This application is primarily used to support the Preboot Execution Environment (PXE) booting of hosts and the updating of network devices. There is no option to authenticate systems at this level by protocol design. TFTP is limited to a user’s local subnet using IPtables and is enforced additionally with TCPWrappers.
+DHCP                By default, system IP addresses are not pooled, but are rather statically assigned to a client, which is identified by the MAC address. DHCP is limited to the local subnet.
+Apache/YUM          RPMs are stored in a directory for systems to use for both kickstart and package updating. Sensitive information should never be stored here. Apache/YUM is limited to the local subnet.
+DNS                 The DNS protocol does not require identification nor authentication. DNS is limited to the local subnet.
+=================== ========================================
+
+Table: Actions Without Identification and Authentication
+
+Security Attributes
+-------------------
+
+:term:`SELinux` is fully enforcing, in targeted mode, in SIMP. SELinux is an
+implementation of :term:`Mandatory Access Control`. It can be set to enforcing
+mode during the SIMP configuration or turned on at a later time. All of the
+SIMP packaged modules have been designed to work with SELinux set to enforcing.
+[:ref:`AC-16`]
+
+Remote Access
+-------------
+
+Remote access in SIMP is performed over :term:`SSH`, specifically using the
+OpenSSH software. OpenSSH provides both confidentiality and integrity of remote
+access sessions. The SSH :term:`IPTables` rules allow connections from any
+host. SSH relies on other Linux mechanisms to provide identification and
+authentication of a user.  As discussed in the auditing section, user actions
+are audited with the audit daemon (``auditd``) and :term:`sudosh`.
+[:ref:`AC-17`]
+
+Systems and Communications Protection
+-------------------------------------
+
+The following sections provide information regarding application partitioning,
+shared resources, and various levels of protection for systems and
+communications.
+
+User and Administration Application Separation (Application Partitioning)
+-------------------------------------------------------------------------
+
+SIMP can be used in a variety of ways. The most common is a platform for
+hosting other services or applications. In that case, there are only
+administrative users present. Users with accounts will be considered as a type
+of privileged user.
+
+SIMP can also be used as a platform for workstations or general users
+performing non-administrative activities. In both cases, general users with
+accounts on an individual host are allowed access to the host using the
+``pam::access`` module, so long as they have an account on the target host. No
+user may perform or have access to administrative functions unless given
+``sudo`` or :term:`sudosh` privileges via Puppet.
+
+Shared Resources
+----------------
+
+There are several layers of access control that prevent the unauthorized
+sharing of resources in SIMP. Account access, operating system :term:`DAC`
+settings, and the use of :term:`PKI` collectively prevent resources from being
+shared in ways that were not intended.
+[:ref:`SC-4`]
+
+Denial of Service Protection
+----------------------------
+
+SIMP has limited ability to prevent or limit the effects of Denial of Service
+(:term:`DoS`) attacks. The primary measures in place are to drop improperly
+formatted packets using :term:`IPTables` and Kernel configurations such as
+:term:`SYN cookies`.
+[:ref:`SC-5`]
+
+Boundary Protection
+-------------------
+
+SIMP does not provide boundary protection. [SC-7]
+
+Transmission Security
+---------------------
+
+SIMP traffic is protected with protocols that provide confidentiality and
+integrity of data while in transit. The tables in :ref:`Flow_Enforcement`
+describe the protocols used to encrypt traffic and explain the protocols that
+cannot be protected at the transmission layer. :term:`SSH`, and :term:`TLS` all
+provide data transmission integrity and confidentiality. The software that
+controls them on Red Hat and CentOS are OpenSSH and OpenSSL. The SIMP team
+takes industry guidance into consideration when configuring these services. For
+example, the list the cryptographic ciphers available is limited to the highest
+ciphers that SIMP needs. All others are disabled.
+[:ref:`SC-8`, :ref:`SC-9`, :ref:`SC-23`, :ref:`SC-7`]
+
+Single User Mode
+----------------
+
+SIMP systems have a password requirement for single user mode. In the event
+maintenance needs to be performed at a system console, users must be in
+possession of the ``root`` password before they can be authenticated.
+Bootloader passwords are also set to prevent unauthorized modifications to boot
+parameters.
+[:ref:`SC-24`]
+
+PKI and Cryptography
+--------------------
+
+SIMP has two native certificate authorities. The first is known as *Fake CA*. A
+local certificate authority is used to create properly formed server
+certificates if an implementation does not have other means of obtaining them.
+Many SIMP services require certificates; therefore, SIMP provides this tool for
+testing or for situations where other certificates are not available. The
+second certificate authority, *Puppet CA*, is built into Puppet. Puppet
+creates, distributes, and manages certificates that are specifically for
+Puppet.
+
+The *Fake CA* certificates should be replaced with your own hardware-generated
+certificates if at all possible. The *Puppet CA* may be replaced but please
+understand all ramifications to the infrastructure before doing so.
+
+More information on the Puppet CA can be found in the Puppet Labs `security documentation <http://projects.puppetlabs.com/projects/1/wiki/certificates_and_security>`__.
+[:ref:`SC-17`, :ref:`SC-13`]
+
+.. WARNING::
+    Fake CA certificates should not be used in an operational setting unless no
+    better options are available.
+
+Mobile Code
+-----------
+
+SIMP does not use mobile code; however, there are not any particular tools that
+will prevent its use.
+[:ref:`SC-18`]
+
+Protection of Information at Rest
+---------------------------------
+
+SIMP provides the capability to enable Full Disk Encryption (FDE) by default.
+However, in the interest of automated reboots, the initial **randomly
+generated** key is baked into the ``initrd``. Please see the
+:ref:`ig-disk-encryption` section of the Installation Guide for details.
+[:ref:`SC-28`]
+
+Audit and Accountability
+------------------------
+
+This section discusses the content, storage, and protection of auditable
+events.
+
+Auditable Events
+----------------
+
+``Auditd`` and ``Rsyslog`` provide the foundation for SIMP auditing. ``Auditd``
+performs the majority of the security-related events; however, other Linux logs
+also have security information in them and are captured using ``rsyslog``.
+
+The default auditable events for SIMP were developed based on several industry
+best practices including those from the SCAP Security Guide and several
+government configuration guides. The suggested rules by those guides were
+fine-tuned so the audit daemon would not fill logs with useless records or
+reduce performance. These guides should be referenced for a detailed
+explanation of why rules are applied. Additional justification can be found in
+the comments of the SIMP audit rules found in the appendix of this guide.
+[:ref:`AU-2`]
+
+The SIMP development team reviews every release of the major security guides
+for updated auditable events suggestions. Each of those suggestions is reviewed
+and applied if deemed applicable.
+[:ref:`AU-2 (3)`]
+
+Privileged commands are audited as part of the SIMP auditing configuration.
+This is accomplished by monitoring ``sudo`` commands with ``auditd``.
+Session interaction for administrators that use :term:`sudosh` are also logged.
+Each ``sudosh`` session can be reviewed using ``sudosh-replay`` and are also
+sent to ``rsyslog``.
+[:ref:`AU-2 (4)`]
+
+Content of Audit Records
+------------------------
+
+Audit records capture the following information [:ref:`AU-3`]:
+
+*  Date and Time
+*  UID and GID of the user performing the action
+*  Command
+*  Event ID
+*  Key
+*  Node Hostname/IP Address
+*  Login Session ID
+*  Executable
+
+Audit Storage
+-------------
+
+Audit logs are stored locally on a separate partition in the ``/var/log``
+directory. The size of this partition is configurable. Other default audit
+storage configurations include:
+
+*  A syslog log is written when the audit partition has **75MB** free. (This
+   can be changed to e-mail, if an e-mail infrastructure is in place.)
+   [:ref:`AU-5a.`, :ref:`AU-5 (1)`]
+*  The log file rotates once it reaches **30MB**.
+
+Audit Reduction and Response
+----------------------------
+
+SIMP provides a means to capture the proper information for audit records and
+stores them centrally. Each implementation must decide and document how it
+reduces, analyzes, and responds to audit events.
+[:ref:`AU-5`]
+
+``Auditd``, like all services in SIMP, is controlled by Puppet. Stopping the
+service without disabling Puppet means the service will always be started
+automatically during a Puppet run. The files that control the audit
+configuration will also revert to their original state if changed manually on a
+client node. In the event ``auditd`` fails, the system will continue to
+operate.  Several security guides have suggested that the system should shut
+down if ``auditd`` fails for any reason. To prevent operational issues, SIMP
+will not shut down, but will provide an alert via ``syslog`` when this happens.
+[:ref:`AU-5 (1)`]
+
+SIMP also comes with an optional module for the Elasticsearch/Logstash/Grafana
+(ELG) stack. These three open source tools can be combined to parse, index, and
+visualize logs. There are also SIMP provided dashboards for the Kibana web
+interface. Implementations can build their own dashboards to meet local
+security or functional needs for log reduction and management.
+[:ref:`AU-6`]
+
+See :ref:`Elasticsearch, Logstash, and Grafana` for more information.
+
+Protection of Audit Information
+-------------------------------
+
+The primary means of protecting the audit logs is through the use of file
+permissions. Audit records are stored in the ``/var/log`` directory and can
+only be accessed by ``root``. Audit logs are rotated off daily if the
+implementation has not developed a way of offloading the logs to another
+location where they can be backed up. Lastly, if the
+``rsyslog::stock::log_server`` module is implemented, logs are transmitted to
+the log server over a TLS protected link.
+
+Time Synchronization
+--------------------
+
+Each SIMP client (including the Puppet Master) has ``ntpd`` enabled by default.
+Part of the installation directs the clients to a time server.  If no servers
+are available, the SIMP clients can use the Puppet Master as the central time
+source. Audit logs receive their time stamp from the local server's system
+clock; therefore, the SIMP client must be connected to a central time source
+for timestamps in audit logs to be accurate.

--- a/docs/security_conop/index.rst
+++ b/docs/security_conop/index.rst
@@ -1,0 +1,12 @@
+SIMP Security Concepts
+================================
+
+Contents:
+
+.. toctree::
+  :maxdepth: 1
+
+  Introduction
+  Technical_Security
+  Operational_Security
+  System_Management

--- a/docs/security_mapping/index.rst
+++ b/docs/security_mapping/index.rst
@@ -1,3 +1,5 @@
+.. _SIMP_Security_Control_Mapping:
+
 SIMP Security Control Mapping
 ================================
 


### PR DESCRIPTION
The new security mapping did not have the depth of coverage that the
old SecCONOP did, therefore it has been restored to work alongside the
mapping and to ensure that adequate information is covered.

The document has been updated and as many policy references as possible
were actively cross-linked against the NIST 800-53.

SIMP-1419 #close