### PR TITLE
(SIMP-1429) Add HOWTO for discarding root's email

### DIFF
--- a/docs/user_guide/HOWTO.rst
+++ b/docs/user_guide/HOWTO.rst
@@ -11,6 +11,7 @@ the SIMP system.
   Change Puppet Masters <HOWTO/Changing_Puppet_Masters>
   Disable dhcpd <HOWTO/Disable_dhcpd>
   Disable named <HOWTO/Disable_named>
+  Discard Mail to Root <HOWTO/Discard_Mail_to_Root>
   Build a bootable SIMP DVD <HOWTO/DVD_Build>
   Exclude YUM Repositories <HOWTO/Exclude_Repositories>
   Enable The Foreman <HOWTO/Foreman>

--- a/docs/user_guide/HOWTO/Discard_Mail_to_Root.rst
+++ b/docs/user_guide/HOWTO/Discard_Mail_to_Root.rst
@@ -1,0 +1,20 @@
+HOWTO Discard Mail to Root
+==========================
+
+In many environments, you may have a central log collection facility, such as
+Logstash, for analyzing your log data. In this case, you may want to disable
+the default behavior of sending all e-mail to root.
+
+The simplest method of discarding root's e-mail is to redirect it to
+``/dev/null`` on the system using the following Puppet code.
+
+.. WARNING::
+  This is a **very** brute force approach and should only be used if you are
+  **absolutely sure** that you want to discard all of root's e-mail on your
+  systems.
+
+.. code-block:: ruby
+
+   ::postfix::alias { 'root':
+     values => '/dev/null'
+   }


### PR DESCRIPTION
In some cases, users will want to disable the default behavior of
sending mail to root on the local system. This HOWTO provides a
brute force way of effecting this.

SIMP-1429 #comment HOWTO for making root's e-mail die

Change-Id: I5a65102d62953b964bf15438771d65cf29d6aad5