### PR TITLE
(SIMP-1218) Fix issue with losing RTD information

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Welcome to the SIMP documentation!
 ==================================
 This is the documentation for the |simp_version| release of SIMP, which is
-compatible with the |rhel_version| release of CentOS and Red Hat Enterprise
+compatible with the |el_version| release of CentOS and Red Hat Enterprise
 Linux (RHEL).  This guide will walk a user through the process of installing
 and managing a :term:`SIMP` system.  It also provides a mapping of security
 features to security requirements, which can be used to document a system's


### PR DESCRIPTION
The previous push to SIMP-1218 caused issues with with information loss
when publishing to ReadTheDocs. This ensures that as much information
as possible is pulled from GitHub when no other sources are available.

Much of this code should probably be consolidated into functions at
some point.

SIMP-1218 #close Fix information loss in RTD