### PR TITLE
Add "rpm-sign" into Required RPMs section of Getting Started Guide

### DIFF
--- a/docs/getting_started_guide/Environment_Preparation.rst
+++ b/docs/getting_started_guide/Environment_Preparation.rst
@@ -22,13 +22,13 @@ Required RPMs
 
     $ sudo yum install -y augeas-devel createrepo genisoimage git gnupg2 \
         libicu-devel libxml2 libxml2-devel libxslt libxslt-devel \
-        mock rpmdevtools clamav gcc gcc-c++ ruby-devel
+        mock rpm-sign rpmdevtools clamav gcc gcc-c++ ruby-devel
 
   # Installing from EL 7:
 
     $ sudo yum install -y augeas-devel createrepo genisoimage git gnupg2 \
         libicu-devel libxml2 libxml2-devel libxslt libxslt-devel \
-        mock rpmdevtools clamav-update gcc gcc-c++ ruby-devel
+        mock rpm-sign rpmdevtools clamav-update gcc gcc-c++ ruby-devel
 
   # Installing from Fedora 22/23:
 


### PR DESCRIPTION
Know what really sucks? Attempting to build a SIMP ISO, waiting ~1hr, and having the build error out because rpm-sign was missing :'( Adding this into the Getting Started Guide.

First contribution to SIMP... wasn't sure if I should patch against master or a branch (or all?).
