### PR TITLE
(SIMP-2134) Updated to use the new SCL repos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Nov 29 2016 Trevor Vaughan <tvaughan@onyxpoint.com>
+- Updated the RPM spec file to use the new SCL repos
+- You *must* have an appropriately configured Mock configuration for this to
+  work!
+
 * Thu Oct 20 2016 Nick Markowski <nmarkowski@keywcorp.com>
 - Updated the getting started guide to clarify what to check
   out to get an expected build of SIMP.

--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -112,7 +112,7 @@ Buildarch: noarch
 %{lua: print(package_requires) }
 Requires: links
 %if 0%{?el6}
-BuildRequires: scl-utils
+BuildRequires: centos-release-scl
 BuildRequires: python27
 %endif
 BuildRequires: python-pip


### PR DESCRIPTION
The way that the SCL repositories are installed changed and caused
issues with the EL 6 builds.

To build, you *must* have the following repositories in your Mock
configuration (this is done for you in SIMP 6 builds):

[centos-sclo-sclo]
name=CentOS-6 - SCLo sclo
baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/sclo/
gpgcheck=1
enabled=1
gpgkey=https://raw.githubusercontent.com/sclorg-distgit/centos-release-sclo/master/RPM-GPG-KEY-CentOS-SIG-SCLo

[centos-sclo-rh]
name=CentOS-6 - SCLo rh
baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/rh/
gpgcheck=1
enabled=1
gpgkey=https://raw.githubusercontent.com/sclorg-distgit/centos-release-sclo/master/RPM-GPG-KEY-CentOS-SIG-SCLo

SIMP-2134 #close