### PR TITLE
[WIP] (SIMP-XXX) Ensure that pip can handle requirements

### DIFF
--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -147,7 +147,9 @@ source /opt/rh/python27/enable
 
 virtualenv venv
 source venv/bin/activate
-pip install --upgrade -r requirements.txt
+
+pip install -U pip>=8.0 # ancient pips break on these requirements
+pip install --upgrade -r requirements.txt --log dist/pip.log
 
 sphinx-build -E -n -t simp_%{simp_major_version} -b html -d sphinx_cache docs html
 sphinx-build -E -n -t simp_%{simp_major_version} -b singlehtml -d sphinx_cache docs html-single


### PR DESCRIPTION
Before this commit, `simp-doc` builds were breaking because the version
of pip (1.4.1) provided by the `epel-7-86_64` virtualenv is insufficient
to install some of the python packages in `requirements.txt`.  This
patch fixes the issue by upgrading pip just before installing the
requirements.

SIMP-XXX #close