### PR TITLE
(SIMP-2570) replaced lmgtfy link with elastic.co link

### DIFF
--- a/docs/user_guide/HOWTO/Central_Log_Collection/Logstash.rst
+++ b/docs/user_guide/HOWTO/Central_Log_Collection/Logstash.rst
@@ -426,6 +426,6 @@ different name.
 .. _Grafana: http://grafana.org/
 .. _SIMP Logstash module: https://github.com/simp/pupmod-simp-simp_logstash
 .. _Logstash documentation: https://www.elastic.co/guide/en/logstash/current/index.html
-.. _Elasticsearch scaling: http://lmgtfy.com/?q=elasticsearch+scaling
+.. _Elasticsearch scaling: https://www.elastic.co/guide/en/elasticsearch/guide/master/_scale_horizontally.html 
 .. _SIMP IPSec: https://github.com/simp/pupmod-simp-libreswan
 .. _simplib passgen(): https://github.com/simp/pupmod-simp-simplib/blob/master/lib/puppet/parser/functions/passgen.rb


### PR DESCRIPTION
While I'm not sure that the elastic.co link is a permanent solution, it's much better than the lmgtfy link that is there now. 