### PR TITLE
(SIMP-2573) Help mock pip to handle requirements

### DIFF
--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -147,7 +147,9 @@ source /opt/rh/python27/enable
 
 virtualenv venv
 source venv/bin/activate
-pip install --upgrade -r requirements.txt
+
+pip install -U pip>=8.0 # ancient pips break on these requirements
+pip install --upgrade -r requirements.txt --log dist/pip.log
 
 sphinx-build -E -n -t simp_%{simp_major_version} -b html -d sphinx_cache docs html
 sphinx-build -E -n -t simp_%{simp_major_version} -b singlehtml -d sphinx_cache docs html-single

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -425,11 +425,16 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-# A regex of yum repos that the linkcheck builder should ignore
+# A regex of links that the linkcheck builder should ignore
 linkcheck_ignore = [
-  r'^http[s]?:\/\/.*epel\/', # epel repos
-  r'^http[s]?:\/\/yum\.puppet' # puppetlabs repos
-  r'^http[s]?:\/\/groups\.google\.com\/forum\/\?fromgroups#!forum\/simp' # these links don't resolve properly in the checker
+    # Links with anchors have issues
+    r'^http[s]?:\/\/.*#\w+$',
+    # ignore rpms
+    r'^http[s]?:\/\/.*\.rpm$',
+    # links that the resolver has trouble with
+    r'^http[s]?:\/\/groups\.google\.com\/forum\/\?fromgroups#!forum\/simp',
+    r'^http[s]?:\/\/travis-ci\.org',
+    r'^http[s]?:\/\/bundler\.io/rationale\.html'
  ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -347,7 +347,7 @@ Glossary of Terms
    Open Source
       Following an Open Source Initiative approved License.
 
-      See: `The Open Source Definition <http://opensource.org/osd-annotated>`__
+      See: `The Open Source Definition <https://opensource.org/osd-annotated>`__
 
    OpenSCAP
       The OpenSCAP project provides tools that are free to use anywhere you
@@ -405,7 +405,7 @@ Glossary of Terms
 
    Puppet
       An :term:`Open Source` configuration management tool written and
-      maintained by `Puppet Labs <http://www.puppet.com>`__. Written as a
+      maintained by `Puppet, Inc <https://puppet.com>`__. Written as a
       Ruby DSL, Puppet provides a declarative language that allows system
       administrators to provide a consistently applied management
       infrastructure. Users describes system resource and resource state in the
@@ -430,7 +430,7 @@ Glossary of Terms
    Red Hat®
    Red Hat®, Inc.
       A collection of many different software programs, developed by
-      `Red Hat®, Inc. <http://www.redhat.com>`__ and other members of the Open
+      `Red Hat®, Inc. <https://www.redhat.com>`__ and other members of the Open
       Source community. All software programs included in Red Hat Enterprise
       Linux® are GPG signed by Red Hat®, Inc. to indicate that they were
       supplied by Red Hat®, Inc.


### PR DESCRIPTION
Before this commit, `simp-doc` builds were breaking because the version
of pip (1.4.1) that comes natively during the build with `epel-7-86_64`
is insufficient to install some of the python packages in
`requirements.txt`.  This patch fixes the issue by upgrading pip just
before installing the requirements.

SIMP-2573 #close