### PR TITLE
(SIMP-2768) Update Redundant LDAP server Document

### DIFF
--- a/docs/user_guide/HOWTO/Redundant_LDAP.rst
+++ b/docs/user_guide/HOWTO/Redundant_LDAP.rst
@@ -54,7 +54,7 @@ Configure the following settings in ``simp_def.yaml`` in the hiera directory:
   # The LDAP root password hash.
   # If you set this with simp config, type the password and the hash will be
   # generated for you.'
-  simp_options::ldap::root_hash: "{SSHA}GSCDnNF6KMXBf1F8eIe5xvQxVJou3zGu"
+  simp_openldap::server::conf::rootpw: "{SSHA}GSCDnNF6KMXBf1F8eIe5xvQxVJou3zGu"
 
   # This is the LDAP master in URI form (ldap://server)
   simp_options::ldap::master: ldap://ldap_server1.your.domain
@@ -111,8 +111,9 @@ add the following lines to the
 
 .. code-block:: yaml
 
+  simp_openldap::server::conf::rootpw: "{SSHA}GSCDnNF6KMXBf1F8eIe5xvQxVJou3zGu"
   simp::server::ldap:is_slave: true
-  simp::server::ldap:rid: "888"
+  simp::server::ldap:rid: 888
 
   classes :
     - 'simp::server::ldap'
@@ -120,7 +121,7 @@ add the following lines to the
 .. _URI:
 
 To make other clients aware of this server, add the redundant server's URI to
-lists of URIs in the ``hieradata/simp_def.yaml`` file:
+lists of URIs in the ``hieradata/default.yaml`` file:
 
 .. code-block:: yaml
 
@@ -133,8 +134,8 @@ lists of URIs in the ``hieradata/simp_def.yaml`` file:
 .. NOTE::
 
  To see the defaults for LDAP replication in SIMP, review the parameters passed
- to the module ``openldap/manifests/server/syncrepl.pp``. These parameters are
- used to add the replication settings to the ``syncrepl.conf`` file.
+ to the module ``simp_openldap/manifests/server/syncrepl.pp``. These parameters
+ are used to add the replication settings to the ``syncrepl.conf`` file.
  Definitions can be found in the syncrepl.conf (5) man page.
 
 
@@ -142,7 +143,7 @@ Custom Replication Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If settings other than the defaults are needed, create a manifest under
-`site::` and use the `openldap::server::syncrepl` class with the necessary
+`site::` and use the `simp_openldap::server::syncrepl` class with the necessary
 parameters.
 
 In this example, the site profile is called `site::ldapslave` and the RID of
@@ -156,12 +157,12 @@ overwritten but you can overwrite any number of them.
     include 'simp::server::ldap'
 
     # custom settings:
-    openldap::server::syncrepl { '999':
+    simp_openldap::server::syncrepl { '999':
       sizelimit  => '5000',
     }
   }
 
-The name of the `openldap::server::syncrepl` instance must be a unique replication id.
+The name of the `simp_openldap::server::syncrepl` instance must be a unique replication id.
 
 Place this file in the `site::` module's  `manifests/` directory using the name
 `ldapslave.pp`.   Include this class from the slave server's hiera .yaml file:
@@ -180,19 +181,19 @@ Promote a Slave Node
 
 Slave nodes can be promoted to act as the LDAP master node. To do this, change
 the node classifications of the relevant hosts.  For a node with the default
-settings, just remove the ``simp::ldap_server::is_slave : true`` from the
-server's hiera .yaml file and change the setting for the master ldap in the
-``simp_def.yaml``.
+settings, just remove the ``simp::server::ldap::is_slave : true`` from the
+server's hiera .yaml file and change the setting for the master ldap in hiera.
+This setting is needed by all ldap servers.  (It defaults to the puppet server
+if it is not set.)
 
 .. code-block:: yaml
 
   # This is the LDAP master in URI form (ldap://server)
-  simp_options::ldap::master: ldap://ldap_server1.your.domain
+  simp_options::ldap::master: ldap://ldap_server2.your.domain
 
 For a redundant server set up using custom settings, remove the call to the
 custom class and replace it with the call to the site::ldap_server class in the
-servers yaml file and set the master setting in the ``simp_def.yaml`` file as
-shown above.
+servers yaml file and set the master setting in the hiera as shown above.
 
 In both cases, if the current master is not down, make sure it has completed
 replication before changing the settings.  Once the settings are changed, run
@@ -205,11 +206,11 @@ Remove a Node or Demote a Master
 To demote a master, simply configure it as slave in either of the
 configurations above after the new master has been configured and put in place,
 then run the puppet agent.  Lastly, manually remove the active database from
-the server. (Check the setting ``openldap::server::conf::directory`` setting
-for the location of the files.)
+the server. (Check the setting ``simp_openldap::server::conf::directory``
+setting for the location of the files.)
 
-To remove an LDAP server, first remove the server from the URI_  settings in
-``simp_def.yaml``.  Give the clients time to update from the puppet server so
+To remove an LDAP server, first remove the server from the ``simp_options::ldap::uri``
+settings in hiera.  Give the clients time to update from the puppet server so
 they do not attempt to call it.  Then remove relevant settings from it's hiera
 .yaml file and run the puppet agent.
 
@@ -217,9 +218,10 @@ Troubleshooting
 ---------------
 
 If the system is not replicating, it is possible that another user has updated
-the ``simp_options::ldap::sync_pw`` and ``simp_options::ldap::sync_hash`` entries in the
-``/etc/puppetlabs/code/environments/simp/simp_def.yaml`` file without also updating the
-value in LDAP itself; this is the most common issue reported by users.
+the ``simp_options::ldap::sync_pw`` and ``simp_options::ldap::sync_hash``
+entries in hiera file without also updating the value in LDAP itself;
+this is the most common issue reported by users.  If simp config was used to
+to set up the server these values are in the ``simp_config_settings.yaml`` file.
 
 Currently, SIMP cannot self-modify the LDAP database directly; therefore, the
 LDAP Administrator needs to perform this action. Refer to the


### PR DESCRIPTION
  - updated the documentation for redundant LDAP server for
    simp V6.

SIMP-2768 #comment  updated the documentation, still need to update tests