### PR TITLE
(SIMP-2819) Document how to use SIMP Rsync

### DIFF
--- a/docs/user_guide/HOWTO.rst
+++ b/docs/user_guide/HOWTO.rst
@@ -7,10 +7,11 @@ the SIMP system.
 .. toctree::
   :maxdepth: 1
 
+  Work with the SIMP Rsync Shares <HOWTO/Work_With_Rsync>
   Setup Central Log Collection <HOWTO/Central_Log_Collection>
   Change Puppet Masters <HOWTO/Changing_Puppet_Masters>
   Discard Mail to Root <HOWTO/Discard_Mail_to_Root>
-  Exclude YUM Repositories <HOWTO/Exclude_Repositories>
+  Exclude YUM Repositories from Nightly Updates <HOWTO/Exclude_Repositories>
   Configure NFS <HOWTO/NFS>
   Configure IPTables NAT Rules <HOWTO/IPTables_NAT_Rules>
   Enable Kerberos <HOWTO/Kerberos>

--- a/docs/user_guide/HOWTO/Puppetmaster_Backup.rst
+++ b/docs/user_guide/HOWTO/Puppetmaster_Backup.rst
@@ -6,17 +6,32 @@ Master.
 
 .. NOTE::
 
-    SIMP, by default, provides two ways to back up data. They are
-    BackupPC and Git. If there is a different preferred method, the user
-    may install it and configure it first.
+   SIMP, by default, provides two ways to back up data. They are BackupPC and
+   Git. If there is a different preferred method, the user may install it and
+   configure it first.
 
 .. WARNING::
 
-    BackupPC may, or may not, work properly for you on RHEL7+ systems.
-    The SIMP team is currently evaluating other options for an inbuilt
-    backup system.
+   BackupPC may, or may not, work properly for you on RHEL7+ systems. The SIMP
+   team is currently evaluating other options for an inbuilt backup system.
 
 1. Backup ``/etc/puppetlabs/puppet/ssl``
 2. Backup ``/etc/puppetlabs/puppet``
-3. Backup ``/srv/rsync`` and/or ``/var/simp/rsync``
-4. **Optional:** Backup ``/var/www``
+3. Backup ``/srv/rsync``
+4. Backup ``/var/simp``
+5. Backup ``\`puppet config --section master print vardir\`/simp``
+6. **Optional:** Backup ``/var/www``
+
+
+**Simple Full Backup Command**
+
+```bash
+tar --selinux --xattrs -czpvf simp_backup-$(date +%Y-%m-%d).tar.gz /etc/puppetlabs /var/simp `puppet config --section master print vardir`/simp /var/www /var/simp
+```
+
+**Simple Full Restore Command**
+
+```bash
+# WARNING: This will overwrite your current system files!
+tar --selinux --xattrs -C / -xzpvf simp_backup-<date>.tar.gz
+```

--- a/docs/user_guide/HOWTO/Work_With_Rsync.rst
+++ b/docs/user_guide/HOWTO/Work_With_Rsync.rst
@@ -1,0 +1,199 @@
+HOWTO Work with the SIMP Rsync Shares
+=====================================
+
+When we added support for multiple environments, the SIMP rsync space in
+``/var/simp/environments/simp/rsync`` became quite complex.
+
+This will guide you through the new rsync layout as well as providing guidance
+on setting up new rsync shares for your various components.
+
+This is very SIMP-specific and does not preclude you from using rsync however
+you like. However, if you want multi-environment support, you'll need to
+replicate something like what we've done for your custom directories.
+
+Why SIMP Uses Rsync
+-------------------
+
+Rsync support was introduced in SIMP in the early days due to the fact that the
+Puppet native file synchronization mechanisms were relatively horrible at
+syncing large files (too much in memory) and large numbers of files in a
+directory tree (too many resources and system load).
+
+Rsync neatly solves both of these issues and is present on all SIMP systems by
+default.
+
+By default, SIMP wraps all rsync connections in an Stunnel connection to
+provide encrypted connections. Additionally, SIMP adds randomly generated
+passwords to sensitive shares to prevent unauthorized connections.
+
+You can restrict this as far as necessary in your environment but the defaults
+should suit most needs.
+
+Standard Capabilities
+---------------------
+
+The standard SIMP rsync shares exist at ``/var/simp/environments/simp/rsync``.
+This is an assumed path and changing this path will break some aspects of the
+system.
+
+Within this directory, you will find a set of files with the name ``.shares``.
+This file is used by the fact ``simp_rsync_environments`` to indicate that all
+directories at the given location should be added as rsync shared directories.
+
+The data structure in the ``simp_rsync_environments`` is based on the **lower
+cased** name of the containing directory. This means that there should
+**NEVER** be two directories with the same name at the same level of the
+directory hierarchy. In this case, the last one present alphabetically will
+win.
+
+As a concrete example, given the following directory structure:
+
+.. code-block:: bash
+
+   var
+   └── simp
+       └── environments
+           └── simp
+               └── rsync
+                   ├── Global
+                   │   ├── .shares
+                   │   └── clamav
+                   │       ├── main.cvd
+                   │       ├── daily.cld
+                   │       └── bytecode.cld
+                   ├── .rsync.facl
+                   ├── README
+                   └── RedHat
+                       ├── Global
+                       │   ├── freeradius
+                       │   ├── .shares
+                       │   ├── tftpboot
+                       │   │   └── linux-install
+                       │   │       └── README
+                       │   ├── dhcpd
+                       │   │   ├── dhcpd.conf
+                       │   │   └── LICENSE
+                       │   ├── snmp
+                       │   │   ├── mibs
+                       │   │   └── dlmod
+                       │   └── apache
+                       │       └── www
+                       │           ├── cgi-bin
+                       │           ├── error
+                       │           │   └── include
+                       │           ├── icons
+                       │           │   └── small
+                       │           └── html
+                       ├── 6
+                       │   ├── bind_dns
+                       │   │   └── LICENSE
+                       │   └── .shares
+                       └── 7
+                           ├── bind_dns
+                           │   └── LICENSE
+                           └── .shares
+
+The following would be returned by the ``simp_rsync_environments`` fact:
+
+.. code-block:: json
+
+   {
+     "simp": {
+       "id": "simp",
+       "rsync": {
+         "id": "rsync",
+         "global": {
+           "id": "Global",
+           "shares": [
+             "clamav"
+           ]
+         },
+         "redhat": {
+           "id": "RedHat",
+           "6": {
+             "id": "6",
+             "shares": [
+               "bind_dns"
+             ]
+           },
+           "7": {
+             "id": "7",
+             "shares": [
+               "bind_dns"
+             ]
+           },
+           "global": {
+             "id": "Global",
+             "shares": [
+               "freeradius",
+               "tftpboot",
+               "dhcpd",
+               "snmp",
+               "apache"
+             ]
+           }
+         }
+       }
+     }
+   }
+
+Breaking this down, the following data is shown:
+
+.. code-block:: json
+
+   {
+    "downcased_directory_name": {
+      "id": "Original_Directory_Name",
+      "downcased_subdirectory_name": {
+        "id": "Original_Subdirectory_Name",
+        "shares": [
+          "Directory One",
+          "directory two"
+        ]
+      }
+    }
+  }
+
+.. NOTE::
+   The presence of the ``.shares`` file in the directory tree tells the
+   ``simp_rsync_environments`` fact that all directories at that level are to
+   be exposed as shares in the returned data structure.
+
+   That said, it is up to your Puppet logic to actually expose them as such!
+
+   See the ``simp::server::rsync_shares`` class to see how we do this for the
+   default rsync shares.
+
+Supporting Additional Environments
+----------------------------------
+
+Generally, in a SIMP environment, you are going to want to start with the
+directory structure that we have and simply copy the entire data structure to a
+directory with your custom name.
+
+.. WARNING::
+   Be sure not to copy any sensitive information into the space!
+
+For example, if you wanted to create the standard dev/test/prod structure, and
+assuming that ``production`` is already symlinked to ``simp``:
+
+```bash
+cd /var/simp/environments
+cp -a simp dev
+cp -a simp test
+```
+
+After this, you will now have an enhanced ``simp_rsync_environments`` data
+structure that holds all of the information for the ``dev``, ``test``,
+``production``, and ``simp`` environments.
+
+You can then manipulate the contents of the different environments to suit your
+needs.
+
+.. NOTE::
+   The contents of the various rsync directories are not under version control
+   by default. While you may add them to a VCS of your choosing (SVN, Git,
+   etc...), there may be some VERY large files present in these directories.
+
+   Make sure your system can handle the load before adding rsync content into a
+   VCS!


### PR DESCRIPTION
Adds full documentation on using SIMP Rsync and some minor
instructions on performing a backup/restore of critical SIMP files.

SIMP-2819 #close