### PR TITLE
(SIMP-3254) Added FAQ regarding Root Logins

### DIFF
--- a/docs/getting_started_guide/Introduction.rst
+++ b/docs/getting_started_guide/Introduction.rst
@@ -9,6 +9,12 @@ What is SIMP?
 Getting Started
 ---------------
 
+.. WARNING::
+
+   Please take a look at the :ref:`faq` documentation prior to installing SIMP.
+   The most relevant questions for new users will always be at the top of the
+   list.
+
 This document provides a quick overview of how to get started with building and
 setting up your SIMP environment.
 
@@ -22,15 +28,15 @@ Once you're done setting up your environment, you should proceed to the
 If issues still remain, please drop us a line on the `SIMP Development Mailing List`_.
 
 .. NOTE::
-  The fastest method for getting started with SIMP is to follow the
-  :ref:`gsg-installing_simp_from_a_repository` guide.
+   The fastest method for getting started with SIMP is to follow the
+   :ref:`gsg-installing_simp_from_a_repository` guide.
 
-  This is the method that you want to use if you are installing on any sort of
-  existing system.
+   This is the method that you want to use if you are installing on any sort of
+   existing system.
 
 .. NOTE::
-  If you need to build an ISO, you should follow the
-  :ref:`gsg-building_simp_from_tarball` guide.
+   If you need to build an ISO, you should follow the
+   :ref:`gsg-building_simp_from_tarball` guide.
 
 .. _SIMP How-To Articles: https://simp-project.atlassian.net/wiki/display/SD/How-to+articles
 .. _SIMP Confluence Page: https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home

--- a/docs/help/FAQ.rst
+++ b/docs/help/FAQ.rst
@@ -1,3 +1,5 @@
+.. _faq:
+
 Frequently Asked Questions
 ==========================
 
@@ -7,5 +9,6 @@ This chapter addresses some of the frequently asked questions (FAQ) about SIMP.
   :maxdepth: 1
 
   FAQ/SIMP_Version_Guide
+  FAQ/Root_Logins
   FAQ/Password_Complexity
   FAQ/Rsync

--- a/docs/help/FAQ/Root_Logins.rst
+++ b/docs/help/FAQ/Root_Logins.rst
@@ -31,9 +31,10 @@ consoles and the first serial device, you would place the following in
 
 .. IMPORTANT::
 
-   If you are working on a system that was not installed from an ISO, you will
-   probably want to do this so that you can login to your system after running
-   ``simp bootstrap``.
+   If you are working on a system that was not installed from an ISO, you 
+   should do this before running ``simp bootstrap``.  Otherwise, unless you have
+   set up other users, you may not be able to log into your system.
+  
 
 Enabling Remote SSH Logins
 --------------------------

--- a/docs/help/FAQ/Root_Logins.rst
+++ b/docs/help/FAQ/Root_Logins.rst
@@ -1,0 +1,46 @@
+.. _faq-root-login:
+
+How can the root user login
+===========================
+
+Keeping in line with general best practice, SIMP does not allow ``root`` to
+login to the system remotely or at local terminals by default.
+
+However, there may be cases where you need to login as ``root`` for perfectly
+valid reasons.
+
+Enabling Terminal Logins
+------------------------
+
+To allow ``root`` to login at the terminal, you will need to set the
+``useradd::securetty`` ``Array`` to include all ``tty`` devices from which you
+wish to allow ``root`` access.
+
+For example, to allow the ``root`` user to login at the first three virtual
+consoles and the first serial device, you would place the following in
+:term:`hiera`:
+
+.. code-block:: yaml
+
+   useradd::securetty:
+     - tty0
+     - tty1
+     - tty2
+     - ttyS0
+
+
+.. IMPORTANT::
+
+   If you are working on a system that was not installed from an ISO, you will
+   probably want to do this so that you can login to your system after running
+   ``simp bootstrap``.
+
+Enabling Remote SSH Logins
+--------------------------
+
+If you need to allow remote ``root`` logins over SSH (we **highly** advise
+against this), you can add the following to :term:`hiera`:
+
+.. code-block:: yaml
+
+   ssh::server::conf::permitrootlogin: true

--- a/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
+++ b/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
@@ -64,7 +64,7 @@ set up a user workstation.  Each ``site::`` class is described in the subsequent
 .. _Graphical Desktop Setup:
 
 Graphical Desktop Setup
-~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Below is an example manifest called
 ``/etc/puppetlabs/code/environments/simp/modules/site/manifests/gui.pp`` for setting up a graphical
@@ -105,7 +105,7 @@ desktop on a user workstation.
 
 
 Workstation Repositories
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 For the site repos use the puppet resource yumrepo to create repo files to point to
 repositories.
@@ -121,7 +121,7 @@ repositories.
 
 
 Virtualization on User Workstations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Below is an example manifest called
 ``/etc/puppetlabs/code/environments/simp/modules/site/manifests/virt.pp``
@@ -178,12 +178,12 @@ To set swappiness values use hiera:
   swap::max_swappiness: 100
 
 Printer Setup
-~~~~~~~~~~~~~
+^^^^^^^^^^^^^
 
 Below are example manifests for setting up a printing environment.
 
 Setting up a Print Client
-^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""
 
 Below is an example manifest called
 ``/etc/puppetlabs/code/environments/simp/modules/site/manifests/print/client.pp`` for setting up a
@@ -208,7 +208,7 @@ print client on EL6.
 
 
 Setting up a Print Server
-^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""
 
 Below is an example manifest called
 ``/etc/puppetlabs/code/environments/simp/modules/site/manifests/print/server.pp`` for setting up a
@@ -239,7 +239,7 @@ Edit the ``site.pp`` file to create a hostgroup for the workstations.  The
 following will make all nodes whose names start with ``ws`` followed any number
 of digits use the ``hieradata/hostgroup/workstation.yaml`` instead of the default:
 
-.. code-block:: puppet
+.. code-block:: ruby
 
   case $facts['hostname'] {
     /^ws\d+.*/: { $hostgroup = 'workstation' }
@@ -274,7 +274,7 @@ VNC Setup
 and workstations remotely through the standard setup or a proxy.
 
 VNC Standard Setup
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
 .. NOTE::
 
@@ -315,29 +315,29 @@ for examples.
 
 .. IMPORTANT::
 
-    Multiple users can log on to the same system at the same time with
-    no adverse effects; however, none of these sessions are persistent.
+   Multiple users can log on to the same system at the same time with
+   no adverse effects; however, none of these sessions are persistent.
 
-    To maintain a persistent VNC session, use the ``vncserver``
-    application on the remote host. Type ``man vncserver`` to reference
-    the manual for additional details.
+   To maintain a persistent VNC session, use the ``vncserver``
+   application on the remote host. Type ``man vncserver`` to reference
+   the manual for additional details.
 
 VNC Through a Proxy
-~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^
 
 The section describes the process to VNC through a proxy. This setup
 provides the user with a persistent VNC session.
 
 .. IMPORTANT::
 
-    In order for this setup to work, the system must have a VNC server
-    (``vserver.your.domain``), a VNC client (``vclnt.your.domain``), and a
-    proxy (``proxy.your.domain``). A ``vuser`` account must also be set up
-    as the account being used for the VNC. The ``vuser`` is a common user
-    that has access to the server, client, and proxy.
+   In order for this setup to work, the system must have a VNC server
+   (``vserver.your.domain``), a VNC client (``vclnt.your.domain``), and a
+   proxy (``proxy.your.domain``). A ``vuser`` account must also be set up
+   as the account being used for the VNC. The ``vuser`` is a common user
+   that has access to the server, client, and proxy.
 
 Modify Puppet
-+++++++++++++
+"""""""""""""
 
 If definitions for the machines involved in the VNC do not already exist
 in Hiera, create an ``/etc/puppetlabs/code/environments/simp/hieradata/hosts/vserv.your.domain.yaml``
@@ -368,7 +368,7 @@ VNC client node
 
 
 Run the Server
-++++++++++++++
+""""""""""""""
 
 As ``vuser`` on ``vserv.your.domain``, type ``vncserver``.
 
@@ -379,12 +379,12 @@ The output should mirror the following:
 Starting applications specified in ``/home/vuser/.vnc/xstartup`` Log file
 is ``/home/vuser/.vnc/vserv.your.domain:<Port Number>.log``
 
-.. note::
+.. NOTE::
 
-    Remember the port number; it will be needed to set up an SSH tunnel.
+   Remember the port number; it will be needed to set up an SSH tunnel.
 
 Set up an SSH Tunnel
-++++++++++++++++++++
+""""""""""""""""""""
 
 Set up a tunnel from the client (vclnt), through the proxy server
 (proxy), to the server (vserv). The table below lists the steps to set
@@ -393,29 +393,33 @@ up the tunnel.
 
 1. On the workstation, type ``ssh -l vuser -L 590***<Port Number>*:localhost:590***<Port Number>***proxy.your.domain**``
 
-  .. NOTE:: This command takes the user to the proxy.
+  .. NOTE::
+
+     This command takes the user to the proxy.
 
 2. On the proxy, type ``ssh -l vuser -L 590***<Port Number>*:localhost:590***<Port Number>***vserv.your.domain**``
 
-  .. NOTE:: This command takes the user to the VNC server.
+  .. NOTE::
+
+     This command takes the user to the VNC server.
 
 Table: Set Up SSH Tunnel Procedure
 
 .. NOTE::
 
-    The port number in 590\ *<Port Number>* is the same port number as
-    previously described. For example, if the *<Port Number>* was 6,
-    then all references below to 590\ *<Port Number>* become 5906.
+   The port number in 590\ *<Port Number>* is the same port number as
+   previously described. For example, if the *<Port Number>* was 6,
+   then all references below to 590\ *<Port Number>* become 5906.
 
 
 Set Up Clients
-++++++++++++++
+""""""""""""""
 
 On ``vclnt.your.domain``, type ``vncviewer localhost:590\ ***<Port
 Number>***`` to open the Remote Desktop viewer.
 
 Troubleshooting VNC Issues
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If nothing appears in the terminal window, X may have crashed. To
 determine if this is the case, type ``ps -ef | grep XKeepsCrashing``


### PR DESCRIPTION
The fact that root logins were not allowed at the console in SIMP 6 was
not well documented.

This adds a FAQ entry and ensures that it is referenced prominently in
the Getting Started Guide.

Also fixed some heading inconsistency in the Managing Workstation
Infrastructures document.

SIMP-3254 #close