### PR TITLE
(SIMP-3387) Ensure that users use https for runpuppet

### DIFF
--- a/docs/getting_started_guide/Installing_SIMP_From_A_Repository.rst
+++ b/docs/getting_started_guide/Installing_SIMP_From_A_Repository.rst
@@ -200,6 +200,11 @@ your clients. That script can be aquired in one of two ways:
    This would be the general technique that you would use to auto-bootstrap
    your clients via ``user-data`` scripts in cloud environments.
 
+   You should take care to ensure that your environment is protected prior to
+   running the ``runpuppet`` script across the Internet. You may want to
+   package it as a signed RPM specific to your environment and deploy it
+   independently.
+
    Be ready to sign your client credentials as systems check in with the
    server!
 
@@ -207,7 +212,7 @@ Run the script on a client. This example assumes the first option from above:
 
 .. code-block:: bash
 
-   $ curl http://<puppet.server.fqdn>/ks/runpuppet | bash
+   $ curl https://<puppet.server.fqdn>/ks/runpuppet | bash
 
 .. _official SIMP YUM repositories: https://packagecloud.io/simp-project
 .. _AWS: https://aws.amazon.com/

--- a/docs/getting_started_guide/Installing_SIMP_From_A_Repository.rst
+++ b/docs/getting_started_guide/Installing_SIMP_From_A_Repository.rst
@@ -212,7 +212,10 @@ Run the script on a client. This example assumes the first option from above:
 
 .. code-block:: bash
 
-   $ curl https://<puppet.server.fqdn>/ks/runpuppet | bash
+   # Remove the ``--insecure`` option if your system has a certificate signed
+   # by a well-known CA.
+
+   $ curl --insecure https://<puppet.server.fqdn>/ks/runpuppet | bash
 
 .. _official SIMP YUM repositories: https://packagecloud.io/simp-project
 .. _AWS: https://aws.amazon.com/

--- a/docs/help/Public_Resources.rst
+++ b/docs/help/Public_Resources.rst
@@ -37,9 +37,14 @@ Mailing Lists
 
    * Announcements about changes to the SIMP environment
 
- * `SIMP Security List`_
+ * `SIMP Security List`_ (security@simp-project.com)
 
-   * A post-only list for alerting the SIMP team to security issues
+   * A post-only alias for alerting the SIMP team to security issues
+   * Use GPG Key `214BCB69`_ if you would like to encrypt messages
+   * If members of the U.S. Government wish to report a Security issue, please
+     send a message to this alias indicating that you wish to file a report
+     over official channels and someone will contact you with further
+     instructions.
 
 Bug Tracking
 ------------
@@ -48,10 +53,11 @@ If you find a bug, we'd like to encourage you to file a bug in our
 `JIRA Bug Tracking`_ system. That said, we're happy to hear about issues in
 whatever manner is easiest for you.
 
+.. _214BCB69: https://pgp.mit.edu/pks/lookup?op=vindex&search=0x178D18EB214BCB69
+.. _JIRA Bug Tracking: https://simp-project.atlassian.net/
+.. _SIMP Announcement List: https://groups.google.com/forum/?fromgroups#!forum/simp-announce
+.. _SIMP Developers List: https://groups.google.com/forum/?fromgroups#!forum/simp-dev
 .. _SIMP Project HipChat: https://www.hipchat.com/ghofvUiYP
 .. _SIMP Q&A Board: https://groups.google.com/forum/?fromgroups#!forum/simp
+.. _SIMP Security List: mailto://security@simp-project.com
 .. _SIMP Users Mailing List: https://groups.google.com/forum/?fromgroups#!forum/simp-users
-.. _SIMP Developers List: https://groups.google.com/forum/?fromgroups#!forum/simp-dev
-.. _SIMP Announcement List: https://groups.google.com/forum/?fromgroups#!forum/simp-announce
-.. _SIMP Security List: mailto://simp-security@googlegroups.com
-.. _JIRA Bug Tracking: https://simp-project.atlassian.net/

--- a/docs/help/Public_Resources.rst
+++ b/docs/help/Public_Resources.rst
@@ -2,7 +2,8 @@ Public Resources
 ================
 
 Many resources are available for getting help with SIMP. For FOSS support, as
-the community can handle it, you can use one of the following resources.
+the community can handle it, you are welcome to use one of the following
+resources.
 
 Live Chat
 ---------
@@ -12,6 +13,7 @@ Live Chat
   * No account is required for this room. However, if you are going to
     participate regularly, please consider signing up for a HipChat account as
     it will allow you to receive offline messages.
+
   * If you choose to sign up, we recommend using a modifier to your email
     address such as `yourname+simp@gmail.com` since HipChat binds your account
     to the group that you join.
@@ -51,5 +53,5 @@ whatever manner is easiest for you.
 .. _SIMP Users Mailing List: https://groups.google.com/forum/?fromgroups#!forum/simp-users
 .. _SIMP Developers List: https://groups.google.com/forum/?fromgroups#!forum/simp-dev
 .. _SIMP Announcement List: https://groups.google.com/forum/?fromgroups#!forum/simp-announce
-.. _SIMP Security List: https://groups.google.com/forum/?fromgroups#!forum/simp-security
+.. _SIMP Security List: mailto://simp-security@googlegroups.com
 .. _JIRA Bug Tracking: https://simp-project.atlassian.net/


### PR DESCRIPTION
* Changed the `runpuppet` download URL to use HTTPS instead of HTTP to
  be in line with best practices.
* Updated the security help link to point to the mailing list directly

SIMP-3387 #close