### PR TITLE
(SIMP-3617) Correct session auditing docs

### DIFF
--- a/docs/help/FAQ/Selinux.rst
+++ b/docs/help/FAQ/Selinux.rst
@@ -1,3 +1,6 @@
+Common Selinux issues
+=====================
+
 .. _faq-selinux:
 
 If you experience a failed boot after running ``simp bootstrap`` with an error

--- a/docs/security_conop/Technical_Security.rst
+++ b/docs/security_conop/Technical_Security.rst
@@ -445,9 +445,9 @@ and applied if deemed applicable.
 
 Privileged commands are audited as part of the SIMP auditing configuration.
 This is accomplished by monitoring ``sudo`` commands with ``auditd``.
-Session interaction for administrators that use :term:`sudosh` are also logged.
-Each ``sudosh`` session can be reviewed using ``sudosh-replay`` and are also
-sent to ``rsyslog``.
+The output of session interaction for administrators that use :term:`sudosh`
+are also logged. Each ``sudosh`` session can be reviewed using
+``sudosh-replay`` and are also sent to ``rsyslog``.
 [:ref:`AU-2 (4)`]
 
 Content of Audit Records

--- a/docs/security_mapping/components/sudosh/session_audit/control.rst
+++ b/docs/security_mapping/components/sudosh/session_audit/control.rst
@@ -1,9 +1,28 @@
 Session Audit
 -------------
 
-The sudosh tool is installed on each SIMP node.  Sudosh is shell that logs the
-user's keystrokes.  The keystrokes are written to a log file
-``/var/log/sudosh/log``.  Another utility, ``sudosh-replay`` is used to replay
-the keystrokes of a session.
+The ``sudosh`` tool is installed on each SIMP node.  It` logs the terminal
+output of user's terminal session, which is written to the log file
+``/var/log/sudosh/log``.  Another utility, ``sudosh-replay`` can be used to
+replay the session.
+
+The PAM module ``pam_tty_audit`` is used to record keystrokes during a ``root``
+user's session.  Additional accounts can be audited by adding them to the
+parameter ``pam::tty_audit_users``,
+
+.. NOTE::
+   As a safeguard against recording sensitive credentials (such as passwords),
+   both ``sudosh`` and ``pam_tty_audit`` do NOT record when ``echo`` is turned off.
+
+.. WARNING::
+   The audit logs **WILL RECORD SENSITIVE DETAILS** (such as passwords) for any
+   scripts or applications that:
+
+   * Do _not_ protect terminal output while entering or echoing sensitive data
+   * AND are run by an audited user (e.g., ``root``)
+
+   It is therefore HIGHLY RECOMMENDED to update any such scripts or
+   applications to turn of echo during these sensitive operations.
+
 
 References: :ref:`AU-14`

--- a/docs/user_guide/HOWTO/Manage_TPM.rst
+++ b/docs/user_guide/HOWTO/Manage_TPM.rst
@@ -134,7 +134,7 @@ Steps
    profile module. This can't be distributed by SIMP for licensing reasons.
 
 #. Add the following settings to your hieradata for nodes that will be using
-   Trusted Boot. It is reccomended to use a `hostgroup` for this.
+   Trusted Boot. It is recommended to use a `hostgroup` for this.
 
    * ``tpm::tboot::sinit_name`` - The name of the binary downloaded in the previous step
    * ``tpm::tboot::sinit_source`` - Where Puppet can find this binary

--- a/docs/user_guide/HOWTO/Manage_TPM.rst
+++ b/docs/user_guide/HOWTO/Manage_TPM.rst
@@ -134,7 +134,7 @@ Steps
    profile module. This can't be distributed by SIMP for licensing reasons.
 
 #. Add the following settings to your hieradata for nodes that will be using
-   Trusted Boot. It is reccomended to use a `hostgroup`_ for this.
+   Trusted Boot. It is reccomended to use a `hostgroup` for this.
 
    * ``tpm::tboot::sinit_name`` - The name of the binary downloaded in the previous step
    * ``tpm::tboot::sinit_source`` - Where Puppet can find this binary

--- a/docs/user_guide/SIMP_Administration/General_Administration/Session_Auditing.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/Session_Auditing.inc
@@ -1,8 +1,8 @@
 Session Auditing
 ----------------
 
-By default, a SIMP system uses :term:`Sudosh` to enable logging of sudo
-sessions to ``Rsyslog``.
+By default, a SIMP system uses :term:`Sudosh` to enable logging the output of
+sudo sessions to ``Rsyslog``.
 
 To open a ``sudo`` session from a regular user to ``root``, you should type
 ``sudo sudosh``.


### PR DESCRIPTION
This patch fixes the incorrect assertion that SIMP uses `sudosh` for 
keystroke logging.  It also fixes minor errors and warnings that affected
compilation.

SIMP-3617 #close