### PR TITLE
(SIMP-3837) simp-doc: Fix broken RPM build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[,
 gem_sources.each { |gem_source| source gem_source }
 
 gem 'rake'
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.0', '< 6'])
+gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.0.2', '< 6'])
 gem 'pry'

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,12 @@
 #!/usr/bin/rake -T
 
 require 'ostruct'
+require 'rake/clean'
 require 'simp/rake'
 require 'yaml'
 require 'find'
+
+CLEAN.include 'build/rpm_metadata'
 
 desc 'Munge Prep'
   desc <<-EOM
@@ -34,6 +37,13 @@ task 'munge:prep' do
     local_simp_core_path = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
   end
   specfile = File.join(local_simp_core_path, 'src', 'assets', 'simp', 'build', 'simp.spec')
+  if File.exist?(specfile)
+    # Tell python code where simp-core is during the RPM build process.
+    # In the RPM build, it builds the source RPM and then installs it
+    # in a temporary location. So, the relative relationship is broken.
+    ENV['SIMP_CORE_PATH'] = local_simp_core_path
+  end
+
   #
   # Default simp-core git tag/branch to use to pull the simp.spec when
   # a local simp.spec file does not exist.  This ensures we build *something*.

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 #!/usr/bin/rake -T
 
+ENV['SIMP_INTERNAL_pkg_ignore'] = 'build/rpm_metadata'
+
 require 'ostruct'
 require 'rake/clean'
 require 'simp/rake'
@@ -435,6 +437,5 @@ end
 
 # We want to prep for build if possible, but not when running `rake -T`, etc...
 Rake.application.tasks.select{|task| task.name.start_with?('docs:', 'pkg:')}.each do |task|
-  task.enhance ['munge:prep'] do
-  end
+  task.enhance ['munge:prep']
 end

--- a/build/simp-doc.spec
+++ b/build/simp-doc.spec
@@ -84,12 +84,6 @@ if req_file then
 end
 }
 
-%if 0%{?el6}
-%define simp_major_version 4
-%else
-%define simp_major_version 5
-%endif
-
 Summary: SIMP Documentation
 Name: simp-doc
 Version: %{lua: print(package_version)}
@@ -151,14 +145,14 @@ source venv/bin/activate
 pip install -U pip>=8.0 # ancient pips break on these requirements
 pip install --upgrade -r requirements.txt --log dist/pip.log
 
-sphinx-build -E -n -t simp_%{simp_major_version} -b html -d sphinx_cache docs html
-sphinx-build -E -n -t simp_%{simp_major_version} -b singlehtml -d sphinx_cache docs html-single
+sphinx-build -E -n -b html -d sphinx_cache docs html
+sphinx-build -E -n -b singlehtml -d sphinx_cache docs html-single
 
 # Rst2pdf is currently broken on references so we have to remove them.
 # This should be removed when this bug is fixed.
 find docs -name "*.rst" -exec sed -i 's/:ref://g' {} \;
 
-sphinx-build -E -n -t simp_%{simp_major_version} -b pdf -d sphinx_cache docs pdf
+sphinx-build -E -n -b pdf -d sphinx_cache docs pdf
 
 if [ ! -d changelogs ]; then
   mkdir changelogs

--- a/docs/conflib/get_simp_version.py
+++ b/docs/conflib/get_simp_version.py
@@ -49,9 +49,18 @@ def get_simp_version(rootdir=ROOTDIR, simp_github_raw_base=SIMP_GITHUB_RAW_BASE,
     # actual branch that we're using
     if on_rtd:
         rtd_version = os.environ.get('READTHEDOCS_VERSION')
-        url_tgt = '/'.join([
-            simp_github_raw_base, 'simp-core', rtd_version, 'src', 'build', 'simp.spec'
-        ])
+        old_version_regex = re.compile('^4.|^5.|^6.0')
+        if (old_version_regex.match(rtd_version) == None):
+          url_tgt = '/'.join([
+            simp_github_raw_base, 'simp-core', rtd_version, 'src', 'assets',
+            'simp', 'build', 'simp.spec'
+          ])
+        else:
+          url_tgt = '/'.join([
+            simp_github_raw_base, 'simp-core', rtd_version, 'src', 'build',
+            'simp.spec'
+          ])
+
         result = __extract_from_url(url_tgt)
         if  valid_version_and_release(result['version'], result['release']):
             retval['version'] = result['version']
@@ -71,7 +80,7 @@ def get_simp_version(rootdir=ROOTDIR, simp_github_raw_base=SIMP_GITHUB_RAW_BASE,
         # Fall back to something valid
         url_tgt = '/'.join([
             simp_github_raw_base, 'simp-core', default_simp_branch, 'src',
-           'build', 'simp.spec'
+           'assets', 'simp', 'build', 'simp.spec'
         ])
         result = __extract_from_url(url_tgt)
         if valid_version_and_release(result['version'],result['release']):


### PR DESCRIPTION
- Fixed bugs that prevented simp-doc RPM from building.
- Fixed bug in which the simp-doc RPM was not built using local
  simp-core.
- Removed OBE simp5/simp6 flags in simp-doc.spec

***This requires simp-rake-helpers >=5.0.2***

SIMP-3837 #close
SIMP-3811 #comment simp-doc fix