### PR TITLE
(SIMP-4443) Document Difference between simp and true in

### DIFF
--- a/docs/user_guide/Certificates/Certificates.inc
+++ b/docs/user_guide/Certificates/Certificates.inc
@@ -24,12 +24,16 @@ applications need to hande certificates differently.
    the ``/etc/pki/simp/x509`` directory on the client. Any applications using them will
    then make a copy in ``/etc/pki/simp_apps/<app name>/x509`` with the correct permissions
    for an application to use.
-2. ``true`` -  Applicatons on the clients will copy the keypairs from a local directory
+2. ``true`` -  Applications on the clients will copy the keypairs from a local directory
    on the client to ``/etc/pki/simp_apps/<app name>/x509``. The default local directory to
    copy from is ``/etc/pki/simp/x509`` but this can be overidden by setting the ``simp_options::pki::source``
    variable.
 3. ``false`` -  The user will have to manage keypairs themselves. You will need to look at
-   each module that uses pki on a client to determine what variables need to be set.
-   NOTE: This does not disable the use of pki in a module.
+   each module that uses PKI on a client to determine what variables need to be set.
 
-The following sections describe how to use manage certificate when using the ``simp`` option.
+   .. NOTE::
+
+     A setting of ``false`` does **not** disable the use of PKI in a module.
+
+The following sections describe how to populate the cental key distribution directory
+that ``pupmod-simp-pki`` uses, when ``simp_options::pki`` is set to ``simp``.

--- a/docs/user_guide/Certificates/Certificates.inc
+++ b/docs/user_guide/Certificates/Certificates.inc
@@ -2,7 +2,7 @@ Apply Certificates
 ==================
 
 All clients in a SIMP system should have :term:`Public Key Infrastructure` (PKI)
-keypairs generated for the server.  These are the refered to as the infrastructure
+keypairs generated for the server.  These are the referred to as the infrastructure
 or server keys.  These certificates are used to encrypt communication
 and identify clients and are used by common applications such as LDAP and Apache.
 
@@ -13,25 +13,23 @@ and identify clients and are used by common applications such as LDAP and Apache
 
    See :ref:`Certificate Management` for more information.
 
-SIMP uses the ``pupmod-simp-pki`` module to help distribute keypairs.
+SIMP uses the ``pupmod-simp-pki`` module to help distribute infrastructure keypairs.
 The global variable, ``simp_options::pki`` determines what parts of the module are
-included.  It can be overridden at several levels if different hosts or
+included.  It can be overridden in hieradata at several levels if different hosts or
 applications need to hande certificates differently.
 
 ``simp_options::pki`` can have one of three settings:
 
-1) ``simp`` -  Keypairs are distributed from a central location on the puppetserver to
-the ``/etc/pki/simp/x509`` directory on the client. Any applications using them will
-then make a copy in ``/etc/pki/simp_apps/<app name>/x509`` with the correct permissions
-for an application to use.
+1. ``simp`` -  Keypairs are distributed from a central location on the puppetserver to
+   the ``/etc/pki/simp/x509`` directory on the client. Any applications using them will
+   then make a copy in ``/etc/pki/simp_apps/<app name>/x509`` with the correct permissions
+   for an application to use.
+2. ``true`` -  Applicatons on the clients will copy the keypairs from a local directory
+   on the client to ``/etc/pki/simp_apps/<app name>/x509``. The default local directory to
+   copy from is ``/etc/pki/simp/x509`` but this can be overidden by setting the ``simp_options::pki::source``
+   variable.
+3. ``false`` -  The user will have to manage keypairs themselves. You will need to look at
+   each module that uses pki on a client to determine what variables need to be set.
+   NOTE: This does not disable the use of pki in a module.
 
-2) ``true`` -  Applicatons on the clients will copy the keypairs from a local directory
-on the client to ``/etc/pki/simp_apps/<app name>/x509``. The default local directory to
-copy from is ``/etc/pki/simp/x509`` but this can be overidden by setting the ``simp_options::pki::source``
-variable.
-
-3) ``false`` -  The user will have to manage keypairs themselves. You will need to look at
-each module that uses pki on a client to determine what variables need to be set.
-NOTE: This does not disable the use of pki in a module.
-
-The following sections describe how to manage certificate when using the ``simp`` option.
+The following sections describe how to use manage certificate when using the ``simp`` option.

--- a/docs/user_guide/Certificates/Certificates.inc
+++ b/docs/user_guide/Certificates/Certificates.inc
@@ -1,10 +1,10 @@
 Apply Certificates
 ==================
 
-All clients in a SIMP system must have :term:`Public Key Infrastructure` (PKI)
-keypairs generated for the server.  These keys reside in the
-``/var/simp/environments/simp/site_files/pki_files/files/keydist`` directory on the
-SIMP server and are served to the clients over the puppet protocol.
+All clients in a SIMP system should have :term:`Public Key Infrastructure` (PKI)
+keypairs generated for the server.  These are the refered to as the infrastructure
+or server keys.  These certificates are used to encrypt communication
+and identify clients and are used by common applications such as LDAP and Apache.
 
 .. NOTE::
 
@@ -13,6 +13,25 @@ SIMP server and are served to the clients over the puppet protocol.
 
    See :ref:`Certificate Management` for more information.
 
-This section provides guidance on installing official certificates or, as an
-interim measure, generating certificates from the Fake (self-signing)
-Certificate Authority provided by SIMP.
+SIMP uses the ``pupmod-simp-pki`` module to help distribute keypairs.
+The global variable, ``simp_options::pki`` determines what parts of the module are
+included.  It can be overridden at several levels if different hosts or
+applications need to hande certificates differently.
+
+``simp_options::pki`` can have one of three settings:
+
+1) ``simp`` -  Keypairs are distributed from a central location on the puppetserver to
+the ``/etc/pki/simp/x509`` directory on the client. Any applications using them will
+then make a copy in ``/etc/pki/simp_apps/<app name>/x509`` with the correct permissions
+for an application to use.
+
+2) ``true`` -  Applicatons on the clients will copy the keypairs from a local directory
+on the client to ``/etc/pki/simp_apps/<app name>/x509``. The default local directory to
+copy from is ``/etc/pki/simp/x509`` but this can be overidden by setting the ``simp_options::pki::source``
+variable.
+
+3) ``false`` -  The user will have to manage keypairs themselves. You will need to look at
+each module that uses pki on a client to determine what variables need to be set.
+NOTE: This does not disable the use of pki in a module.
+
+The following sections describe how to manage certificate when using the ``simp`` option.

--- a/docs/user_guide/Certificates/Official_Certificates.inc
+++ b/docs/user_guide/Certificates/Official_Certificates.inc
@@ -6,35 +6,53 @@ official certificate authority on the puppetserver for distribution to client
 servers.  You need to have simp_options::pki set to ``simp`` on the client for
 this to work.
 
-The key distribution directory on the puppetserver is located under the site_files directory.
-The site_files directory is an alternate module path set in each environment's environment.conf file.
-By default the site_files directory is ``/var/simp/environments/simp/site_files/``
-and the key distribution directory is ``pki_files/files/keydist``.  The system expects each client
-to have a directory that is its FQDN and the certs should be named with the FQDN.
+The key distribution directory on the puppetserver is the ``pki_files/files/keydist``
+sub-directory located under the SIMP-specific, alternate module path,
+``/var/simp/environments/<environment>/site_files``. Within the ``keydist``
+directory, the SIMP system expects there to be
 
-To install official certificates on the puppetserver do the following:
+  * A directory named ``cacerts`` that contains the :term:`CA` public certificates.
+  * Client-specific directories, each of which contains the public and private
+    certificates for an individual client.  The name of each client directory must
+    be the ``certname`` of that client, which by default is the client's FQDN.
+
+Here is an example key distribution directory for a ``simp`` environment:
+
+.. code-block:: shell
+
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/cacerts/
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/cacerts/cacert_a7a23f33.pem
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/cacerts/cca9a35.0
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomputer.my.domain/
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomputer.my.domain/mycomputer.my.domain.pem
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomputer.my.domain/mycomputer.my.domain.pub
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/yourcomputer.your.domain/
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/yourcomputer.your.domain/yourcomputer.your.domain.pem
+   /var/simp/environments/simp/site_files/pki_files/files/keydist/yourcomputer.your.domain/yourcomputer.your.domain.pub
+
+To install official certificates on the puppetserver, do the following:
 
 1. Copy the certificates received from a proper :term:`CA` to the SIMP server.
-2. Add the certificates for the node to key disttibution directory in the site_files.
+2. Add the certificates for the node to the key distribution directory in ``site_files``.
 
-   a) Make the directory  under the key distribution directory for the clients certificates using the clients FQDN.
-   b) Copy the official certificate to that directory using the FQDN and the correct extension.
-   c) Make sure the permissions are correct.
+   a) Make the directory under the key distribution directory for the clients certificates using
+      the client's ``certname``.
+   b) Copy the official public and private certificates to that directory.
 
-   For example to install certificates for a system named mycomputer.my.domain:
+   For example to install certificates for a system named ``mycomputer.my.domain`` into the ``simp`` environment:
 
    .. code-block:: shell
 
-     mkdir -p /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomuter.my.domain
-     mv /dir/where/the/certs/were/myprivatecert.pem /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomupter.my.domain.pem
-     mv /dir/where/the/certs/were/mypubliccert.pub /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomupter.my.domain.pub
-     chown -R root.puppet /var/simp/environments/simp/site_files/pki_files/files/keydist
-     chmod -R u=rwX,g=rX,o-rwx /var/simp/environments/simp/site_files/pki_files/files/keydist
+     mkdir -p /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomputer.my.domain
+     mv /dir/where/the/certs/were/myprivatecert.pem \
+        /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomputer.my.domain/mycomputer.my.domain.pem
+     mv /dir/where/the/certs/were/mypubliccert.pub \
+        /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomputer.my.domain/mycomputer.my.domain.pub
 
-3. Create and populate the certificate authority certs directory.
+3. Create and populate the :term:`CA` certificates directory.
 
-   a) Make the CA directory.
-   b) Copy the root CA public certificates into cacerts in Privacy Enhanced Mail (PEM) format (one per file).
+   a) Make the CA directory, ``cacerts``.
+   b) Copy the root CA public certificates into ``cacerts`` in Privacy Enhanced Mail (PEM) format, one per file.
 
    .. code-block:: shell
 
@@ -43,8 +61,26 @@ To install official certificates on the puppetserver do the following:
      cd cacerts
      for file in *.pem; do ln -s $file `openssl x509 -in $file -hash -noout`.0; done
 
-Generating Certificates from the Fake CA
-----------------------------------------
+4.  Make sure the permissions are correct
+
+   .. code-block:: shell
+
+     chown -R root.puppet /var/simp/environments/simp/site_files/pki_files/files/keydist
+     chmod -R u=rwX,g=rX,o-rwx /var/simp/environments/simp/site_files/pki_files/files/keydist
+
+.. NOTE::
+
+   The SIMP-specific alternate modules path is configured in each environment's
+   ``environment.conf`` file.  For example, for the ``simp`` environment,
+   ``/etc/puppetlabs/code/environments/simp/environment.conf``, would contain:
+
+   .. code-block:: shell
+
+      modulepath = modules:/var/simp/environments/simp/site_files:$basemodulepath
+
+
+Generating Infrastructure Certificates from the Fake CA
+-------------------------------------------------------
 
 The Fake (self signing) Certificate Authority (Fake CA) is provided by SIMP
 as a way to obtain server certificates if official certificates could not be

--- a/docs/user_guide/Certificates/Official_Certificates.inc
+++ b/docs/user_guide/Certificates/Official_Certificates.inc
@@ -47,8 +47,9 @@ Generating Certificates from the Fake CA
 ----------------------------------------
 
 The Fake (self signing) Certificate Authority (Fake CA) is provided by SIMP
-as a way to obtain server certificates if officail certificates could not be
-obtained at the time of client installation or in testing environments.
+as a way to obtain server certificates if official certificates could not be
+obtained at the time of client installation or the servers are operating in
+testing environments.
 
 .. NOTE::
 

--- a/docs/user_guide/Certificates/Official_Certificates.inc
+++ b/docs/user_guide/Certificates/Official_Certificates.inc
@@ -1,38 +1,54 @@
 Installing Official Certificates
 --------------------------------
 
-Below are the steps to install official certificates for a SIMP client on
-the SIMP server:
+This section describes how to install infrastructure certificates from an
+official certificate authority on the puppetserver for distribution to client
+servers.  You need to have simp_options::pki set to ``simp`` on the client for
+this to work.
+
+The key distribution directory on the puppetserver is located under the site_files directory.
+The site_files directory is an alternate module path set in each environment's environment.conf file.
+By default the site_files directory is ``/var/simp/environments/simp/site_files/``
+and the key distribution directory is ``pki_files/files/keydist``.  The system expects each client
+to have a directory that is its FQDN and the certs should be named with the FQDN.
+
+To install official certificates on the puppetserver do the following:
 
 1. Copy the certificates received from a proper :term:`CA` to the SIMP server.
-2. Add the keys for the node to ``/var/simp/environments/simp/site_files/pki_files/files/keydist``.
+2. Add the certificates for the node to key disttibution directory in the site_files.
 
-  a) Type ``mkdir -p /var/simp/environments/simp/site_files/pki_files/files/keydist/***<Client System FQDN>***``
-  b) Type
+   a) Make the directory  under the key distribution directory for the clients certificates using the clients FQDN.
+   b) Copy the official certificate to that directory using the FQDN and the correct extension.
+   c) Make sure the permissions are correct.
 
-     .. code-block:: bash
+   For example to install certificates for a system named mycomputer.my.domain:
 
-       mv ***<Certificate Directory>***/***<FQDN>***.[pem|pub] \
-       /var/simp/environments/simp/site_files/pki_files/files/keydist/***<FQDN>***
+   .. code-block:: shell
 
-  c) Type ``chown -R root.puppet /var/simp/environments/simp/site_files/pki_files/files/keydist``
-  d) Type ``chmod -R u=rwX,g=rX,o-rwx /var/simp/environments/simp/site_files/pki_files/files/keydist``
+     mkdir -p /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomuter.my.domain
+     mv /dir/where/the/certs/were/myprivatecert.pem /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomupter.my.domain.pem
+     mv /dir/where/the/certs/were/mypubliccert.pub /var/simp/environments/simp/site_files/pki_files/files/keydist/mycomupter.my.domain.pub
+     chown -R root.puppet /var/simp/environments/simp/site_files/pki_files/files/keydist
+     chmod -R u=rwX,g=rX,o-rwx /var/simp/environments/simp/site_files/pki_files/files/keydist
 
-3. Create and populate the ``/var/simp/environments/simp/site_files/pki_files/files/keydist/cacerts``
-   directory.
+3. Create and populate the certificate authority certs directory.
 
-  a) Type ``cd /var/simp/environments/simp/site_files/pki_files/files/keydist``
-  b) Type ``mkdir cacerts`` and copy the root CA public certificates into cacerts in Privacy
-     Enhanced Mail (PEM) format (one per file).
-  c) Type ``cd cacerts``
-  d) Type ``for file in *.pem; do ln -s $file `openssl x509 -in $file -hash -noout`.0; done``
+   a) Make the CA directory.
+   b) Copy the root CA public certificates into cacerts in Privacy Enhanced Mail (PEM) format (one per file).
+
+   .. code-block:: shell
+
+     cd /var/simp/environments/simp/site_files/pki_files/files/keydist
+     mkdir cacerts
+     cd cacerts
+     for file in *.pem; do ln -s $file `openssl x509 -in $file -hash -noout`.0; done
 
 Generating Certificates from the Fake CA
 ----------------------------------------
 
-If server certificates have not or could not be obtained at the time of client
-installation, SIMP provides a way to create them for the system, so that it
-will work until proper certificates are provided.
+The Fake (self signing) Certificate Authority (Fake CA) is provided by SIMP
+as a way to obtain server certificates if officail certificates could not be
+obtained at the time of client installation or in testing environments.
 
 .. NOTE::
 
@@ -60,12 +76,7 @@ Below are the steps to generate the certificates using the SIMP-provided, Fake C
      Ensure that the ``cacertkey`` file is not empty. If it is, enter text into
      the file; then save and close the file.
 
-5. Type ``./gencerts_nopass.sh auto``
-
-  .. NOTE::
-
-     To avoid using the default Fake CA values, remove the ``auto`` statement
-     from the ``./gencerts_nopass.sh`` command.
+5. Type ``./gencerts_nopass.sh``
 
 .. WARNING::
 
@@ -74,9 +85,45 @@ Below are the steps to generate the certificates using the SIMP-provided, Fake C
    old CA. To troubleshoot certificate problems, see the
    :ref:`cm-troubleshoot-cert-issues` section.
 
-If issues arise while generating keys, type ``cd /etc/puppetlabs/code/environments/simp/FakeCA``
-to navigate to the ``/etc/puppetlabs/code/environments/simp/FakeCA`` directory, then type
+If issues arise while generating keys, type ``cd /var/simp/environments/simp/FakeCA``
+to navigate to the ``/var/simp/environments/simp/FakeCA`` directory, then type
 ``./clean.sh`` to start over.
 
 After running the ``clean.sh`` script, type ``./gencerts_nopass.sh`` to
 run the script again using the previous procedure table.
+
+The certificates generated by the FakeCA in SIMP are set to expire annually. To change
+this, edit the following files with the number of days for the desired lifespan of the
+certificates:
+
+
+-  ``/var/simp/environments/simp/FakeCA/CA``
+
+-  ``/var/simp/environments/simp/FakeCA/ca.cnf``
+
+-  ``/var/simp/environments/simp/FakeCA/default\_altnames.cnf``
+
+-  ``/var/simp/environments/simp/FakeCA/default.cnf``
+
+-  ``/var/simp/environments/simp/FakeCA/user.cnf``
+
+In addition, any certificates that have already been created and signed will
+have a config file containing all of its details in
+``/var/simp/environments/simp/FakeCA/output/conf/``.
+
+.. IMPORTANT::
+
+    Editing any entries in the above mentioned config files will **not** affect
+    existing certificates. Existing certificates must be regenerated if you need
+    to make changes.
+
+The following is an example of how to change the expiration time from one year
+(the default) to five years for any newly created certificate.
+
+.. code-block:: bash
+
+   for file in $(grep -rl 365 /var/simp/environments/simp/FakeCA/)
+   do
+      sed -i 's/365/1825/' $file
+   done
+

--- a/docs/user_guide/Client_Management.rst
+++ b/docs/user_guide/Client_Management.rst
@@ -140,7 +140,7 @@ Run ``puppet agent -t`` on the Puppet Master to apply the changes.
 
 
 Setting Up the Client
----------------------
+=====================
 
 The following lists the steps to :term:`PXE` boot the system and set up the
 client.

--- a/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
@@ -16,34 +16,24 @@ requires valid identifying SSL certificates. The Puppet master acts as the certi
 authority for managing these certificates.
 
 The client will automatically send a certificate request to the server if it can not find
-a valid certifcate. The puppetserver will automatically sign a certificate request if the
+a valid certificate. The puppetserver will automatically sign a certificate request if the
 the client's name is in the  ``autosign.conf`` file, otherwise an administrator must sign
 the request using the ``puppet cert`` tool.
-
-For documentation on the ``puppet cert`` tool, visit the `Puppet Inc. cert manual`_.
-
-You can find the location for the Puppet certificates on your system by running
-``puppet config print ssldir``.
-
-For some general information on troubleshooting Puppet certificates see the
-section :ref:`ug-puppet-certificate-issues`.
 
 .. NOTE::
 
    By default, Puppet certificates expire every five (5) years.
-
-.. _Puppet Inc. cert manual: https://docs.puppet.com/puppet/latest/man/cert.html
 
 Infrastructure Certificates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Infrastructure certificates, commonly refered to as server certificates,
 are the standard :term:`PKI` certificates assigned by an official :term:`CA`.
-These are used by all other applications that require certifcates.
+These are used by all other applications that require certificates.
 
 SIMP offers capabilities to help manage these certificates including a FakeCA
 utility that will provide self-signed certificates for use  on testing systems
-or until official certifcates can be obtained.
+or until official certificates can be obtained.
 
 The modules in SIMP have been designed so that infrastructure certificates
 can be managed from a central location and SIMP will distribute them to the applications

--- a/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
@@ -4,71 +4,51 @@ Certificate Management
 ----------------------
 
 This section describes the two different types of certificates used in a SIMP
-system and how to manage them. For information on initial certificate setup,
-refer to the :ref:`Certificates` section of :ref:`Client_Management`.
-
-
-Infrastructure Certificates
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Server certificates are the standard :term:`PKI` certificates assigned either
-by an official :term:`CA` (preferred) or generated using the FakeCA utility
-offered by SIMP. Generated certificates are placed in the ``/etc/pki/simp``
-directory of all managed systems.  These certificates are set to expire
-annually. To change this, edit the following files with the number of days for
-the desired lifespan of the certificates:
-
-.. NOTE::
-
-    This assumes that the user has generated Certificates with the FakeCA
-    provided by SIMP. If official certificates are being used, these settings
-    **must be changed within the official CA, not on the SIMP system**.
-
--  ``/var/simp/environments/simp/FakeCA/CA``
-
--  ``/var/simp/environments/simp/FakeCA/ca.cnf``
-
--  ``/var/simp/environments/simp/FakeCA/default\_altnames.cnf``
-
--  ``/var/simp/environments/simp/FakeCA/default.cnf``
-
--  ``/var/simp/environments/simp/FakeCA/user.cnf``
-
-In addition, any certificates that have already been created and signed will
-have a config file containing all of its details in
-``/var/simp/environments/simp/FakeCA/output/conf/``.
-
-.. IMPORTANT::
-
-    Editing any entries in the above mentioned config files will **not** affect
-    existing certificates. Existing certificates must be regenerated if you need
-    to make changes.
-
-The following is an example of how to change the expiration time from one year
-(the default) to five years for any newly created certificate.
-
-.. code-block:: bash
-
-   for file in $(grep -rl 365 /var/simp/environments/simp/FakeCA/)
-   do
-      sed -i 's/365/1825/' $file
-   done
+and provides links to further information.
 
 
 Puppet Certificates
 ^^^^^^^^^^^^^^^^^^^
 
-Puppet certificates are issued and maintained strictly within Puppet.  They are
-different from the server certificates and should be managed with the
-``puppet cert`` utility.
+Puppet certificates are issued and maintained strictly within Puppet.  Communication
+between the master and agents is granted and secured with HTTPS, which
+requires valid identifying SSL certificates. The Puppet master acts as the certificate
+authority for managing these certificates.
+
+The client will automatically send a certificate request to the server if it can not find
+a valid certifcate. The puppetserver will automatically sign a certificate request if the
+the client's name is in the  ``autosign.conf`` file, otherwise an administrator must sign
+the request using the ``puppet cert`` tool.
 
 For documentation on the ``puppet cert`` tool, visit the `Puppet Inc. cert manual`_.
 
 You can find the location for the Puppet certificates on your system by running
 ``puppet config print ssldir``.
 
+For some general information on troubleshooting Puppet certificates see the
+section :ref:`ug-puppet-certificate-issues`.
+
 .. NOTE::
 
    By default, Puppet certificates expire every five (5) years.
 
 .. _Puppet Inc. cert manual: https://docs.puppet.com/puppet/latest/man/cert.html
+
+Infrastructure Certificates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Infrastructure certificates, commonly refered to as server certificates,
+are the standard :term:`PKI` certificates assigned by an official :term:`CA`.
+These are used by all other applications that require certifcates.
+
+SIMP offers capabilities to help manage these certificates including a FakeCA
+utility that will provide self-signed certificates for use  on testing systems
+or until official certifcates can be obtained.
+
+The modules in SIMP have been designed so that infrastructure certificates
+can be managed from a central location and SIMP will distribute them to the applications
+that need them.
+
+For more information on how to manage infrastructure certificates and how to use the
+FakeCA utility refer to the :ref:`Certificates` section of :ref:`Client_Management`.
+

--- a/docs/user_guide/Troubleshooting/Puppet_Certificate_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Certificate_Issues.rst
@@ -1,3 +1,5 @@
+.. _ug-puppet-certificate-issues:
+
 Puppet Certificate Issues
 =========================
 


### PR DESCRIPTION
simp_options::pki
- updated documentation
- consolidate FakeCA documentation in one place.
- remove comment about auto for gencerts because it doesn't do anything.

SIMP-4443 #close
SIMP-4474 #close
SIMP-4475 #close