### PR TITLE
(SIMP-4989) Pin reportlab to 3.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ docutils>=0.12
 pdfrw>=0.2
 pylint>=1.6
 pytz>=2015.4
-reportlab>=3.2.0
+reportlab==3.4.0
 rst2pdf>=0.93
 six>=1.9.0
 snowballstemmer>=1.2.0


### PR DESCRIPTION
There is a bug in `reportlab` 3.5.0 that renders it inoperable with
`rst2pdf`.