### PR TITLE
(SIMP-4958) Updates docs for EFI tftpboot

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Mon Aug 13 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com>
+- Updated PXE boot instructions for UEFI.
+- Added section for 6.1.0 -> 6.2.0 upgrade for files that need to be updated.
+- Changed For Impatient to Quick Start
+
 * Wed Jun 20 2018 Nick Miller <nick.miller@onyxpoint.com>
 - Added justification for V-71849 results, when SIMP changes vendored
   permissions on RPM provided files

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem_sources.each { |gem_source| source gem_source }
 gem 'rake'
 gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.0.2', '< 6'])
 gem 'pry'
+gem 'net-telnet', ['< 0.2.0']

--- a/docs/getting_started_guide/Just_Install.rst
+++ b/docs/getting_started_guide/Just_Install.rst
@@ -1,4 +1,4 @@
-For The Impatient
+Quick Start
 =================
 
 What is SIMP?

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -696,6 +696,14 @@ Glossary of Terms
    Trusted Boot
      See :term:`TXT`.
 
+   UEFI
+   Unified Extensive Firmware Interface
+      A specification that defines a software interface between an operating system
+      and platform firmware. UEFI replaces the Basic Input/Output System (BIOS)
+      firmware interface.
+
+      Source: `Wikipedia: UEFI <https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface>`__
+
    UUID
    Universally Unique Identifier
       A 128-bit unique value that is generally written as groups of hexadecimal

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Contents:
   :numbered:
   :maxdepth: 2
 
-  For the Impatient <getting_started_guide/Just_Install>
+  Quick Start <getting_started_guide/Just_Install>
   Changelog <dynamic/Changelog>
   Getting Started <getting_started_guide/index>
   User Guide <user_guide/index>

--- a/docs/user_guide/Client_Management.rst
+++ b/docs/user_guide/Client_Management.rst
@@ -40,7 +40,7 @@ add the ``simp::server::kickstart`` class.
   classes:
     - simp::server::kickstart
 
-This profile class adds management of bind_dns and named, as well as sets up the
+This profile class adds management of ``bind_dns`` and ``named``, as well as sets up the
 example provisioning script.
 
 After adding the above class, run puppet: ``puppet agent -t``.
@@ -55,7 +55,7 @@ include DNS configuration files and can be found at
 ``/var/simp/environments/simp/rsync/<OSTYPE>/<MAJORRELEASE>/bind_dns/default``.
 
 This section is not a complete manual for named. For more complete documentation
-on how to set up named, see named(8) and named.conf(5).
+on how to set up ``named``, see named(8) and named.conf(5).
 
 The following configuration steps are for a SIMP-managed setup. However, you
 can use an existing DNS infrastructure.
@@ -105,11 +105,12 @@ Configure DHCP
 
 .. NOTE::
 
-  The ``dhcpd.conf`` file was updated in SIMP 6.2 to include lines the enable the
-  DHCP server to determine if a client is booting in UEFI or Legacy mode, and then
-  select the appropriate initial boot file on the TFTP server.  If you have
-  configured DHCPD using an earlier version of SIMP, make sure you update the
-  your version of dhcpd.conf in the rsync directory, appropriately.
+  The ``dhcpd.conf`` file was updated in SIMP 6.2 to include logic in the
+  ``pxeclients`` class that determines the appropriate boot loader file on the
+  TFTP server, based on whether the client is booting in :term:`UEFI` or
+  :term:`BIOS` mode.  If you have configured DHCP using an earlier version
+  of SIMP and need to add UEFI support, make sure you update your ``dhcpd.conf``
+  in the rsync directory, appropriately.
 
 Perform the following actions as ``root`` on the Puppet Master system
 prior to attempting to install a client.
@@ -133,10 +134,10 @@ Make sure the following is done in the ``dhcpd.conf`` :
     - Enter the domain name for option **domain-name**
     - Enter the IP Address of the DNS server for option **domain-name-servers**
     - If PXE booting is being done with this DHCP server, make sure each ``filename``
-      parameter corresponds to the correct file on the TFTP server.  If you are using
-      SIMP's ``simp::server::kickstart`` class to manage the TFTP server, the
-      default ``filename`` values listed at the top of the sample ``dhpcd.conf``
-      will be correct.
+      parameter corresponds to the correct boot loader file on the TFTP server.
+      If you are using SIMP's ``simp::server::kickstart`` class to manage the
+      TFTP server, the default ``filename`` values listed in the ``pxeclients``
+      class of the sample ``dhpcd.conf`` will be correct.
 
 Save and close the file.
 
@@ -158,16 +159,16 @@ Setting Up the Client
 The following lists the steps to :term:`PXE` boot the system and set up the
 client.
 
-#. Set up your client's :term:`BIOS` or virtual settings to boot off the
-   network.
+#. Set up your client's boot settings to boot off of the network.
 #. Make sure the :term:`MAC` address of the client is set up in :term:`DHCP`
    (see `Configure DHCP`_ for more info.)
 #. Restart the system.
 #. Once the client installs, reboots, and begins to bootstrap, it will check in
    for the first time.
-#. Puppet will not autosign puppet certificates by default and waitforcert is
-   enabled. The client will check in every 30 seconds for a signed cert. Log on
-   to the puppet server and run ``puppet cert sign <puppet.client.fqdn>``.
+#. Puppet will not autosign puppet certificates, by default, and ``waitforcert`` is
+   enabled. This means the client will check in every 30 seconds for a signed
+   certificate.  Log on to the puppet server and run
+   ``puppet cert sign <puppet.client.fqdn>``.
 
 Upon successful deployment of a new client, it is highly recommended that
 :ref:`LDAP administrative accounts <Managing LDAP Users>` be created.

--- a/docs/user_guide/Client_Management.rst
+++ b/docs/user_guide/Client_Management.rst
@@ -105,10 +105,11 @@ Configure DHCP
 
 .. NOTE::
 
-  The dhcpd.conf header was updated in SIMP 6.2 to include lines the enable the DHCP
-  server to determine if a client is booting in UEFI or Lagacy mode and select the
-  appropriate tftp directory.  Make sure you have updated the rsync directory with
-  this file.
+  The ``dhcpd.conf`` file was updated in SIMP 6.2 to include lines the enable the
+  DHCP server to determine if a client is booting in UEFI or Legacy mode, and then
+  select the appropriate initial boot file on the TFTP server.  If you have
+  configured DHCPD using an earlier version of SIMP, make sure you update the
+  your version of dhcpd.conf in the rsync directory, appropriately.
 
 Perform the following actions as ``root`` on the Puppet Master system
 prior to attempting to install a client.
@@ -131,10 +132,11 @@ Make sure the following is done in the ``dhcpd.conf`` :
       additional ones as needed.)
     - Enter the domain name for option **domain-name**
     - Enter the IP Address of the DNS server for option **domain-name-servers**
-    - If PXE booting is being done with this DHCP server, make sure the filename
-      entries  corresponds to the correct file in the tftpserver.
-      If the defaults were used setting up the tftpserver, the default here will
-      be corret.
+    - If PXE booting is being done with this DHCP server, make sure each ``filename``
+      parameter corresponds to the correct file on the TFTP server.  If you are using
+      SIMP's ``simp::server::kickstart`` class to manage the TFTP server, the
+      default ``filename`` values listed at the top of the sample ``dhpcd.conf``
+      will be correct.
 
 Save and close the file.
 
@@ -170,7 +172,6 @@ client.
 Upon successful deployment of a new client, it is highly recommended that
 :ref:`LDAP administrative accounts <Managing LDAP Users>` be created.
 
-
 Troubleshooting Puppet Issues
 -----------------------------
 
@@ -184,7 +185,7 @@ server, try the following options:
 * Remove ``/etc/puppetlabs/puppet/ssl`` on the client system; run ``puppet cert
   --clean ***<Client Host Name>***`` on the Puppet server and try again.
 
-If you are getting permission errors make sure the selinux context is correct on all
+If you are getting permission errors, make sure the selinux context is correct on all
 files as well as the owner and group permissions.
 
 .. _cm-troubleshoot-cert-issues:

--- a/docs/user_guide/Client_Management.rst
+++ b/docs/user_guide/Client_Management.rst
@@ -103,6 +103,13 @@ can use an existing DNS infrastructure.
 Configure DHCP
 ^^^^^^^^^^^^^^
 
+.. NOTE::
+
+  The dhcpd.conf header was updated in SIMP 6.2 to include lines the enable the DHCP
+  server to determine if a client is booting in UEFI or Lagacy mode and select the
+  appropriate tftp directory.  Make sure you have updated the rsync directory with
+  this file.
+
 Perform the following actions as ``root`` on the Puppet Master system
 prior to attempting to install a client.
 
@@ -124,6 +131,10 @@ Make sure the following is done in the ``dhcpd.conf`` :
       additional ones as needed.)
     - Enter the domain name for option **domain-name**
     - Enter the IP Address of the DNS server for option **domain-name-servers**
+    - If PXE booting is being done with this DHCP server, make sure the filename
+      entries  corresponds to the correct file in the tftpserver.
+      If the defaults were used setting up the tftpserver, the default here will
+      be corret.
 
 Save and close the file.
 
@@ -172,6 +183,9 @@ server, try the following options:
   serious issues with certificates.
 * Remove ``/etc/puppetlabs/puppet/ssl`` on the client system; run ``puppet cert
   --clean ***<Client Host Name>***`` on the Puppet server and try again.
+
+If you are getting permission errors make sure the selinux context is correct on all
+files as well as the owner and group permissions.
 
 .. _cm-troubleshoot-cert-issues:
 

--- a/docs/user_guide/PXE_Boot.rst
+++ b/docs/user_guide/PXE_Boot.rst
@@ -8,8 +8,8 @@ located in the DVD under ``/images/pxeboot``.  If you have an existing
 SIMP client. Follow your own sites procedures for this.
 
 In this section we describe how to configure the Kickstart and TFTP servers to
-PXE boot a SIMP client.  (The DHCP server setup, also required for PXE booting,
-is discussed in and earlier chapter.)
+PXE boot a SIMP client.  (The DNS and DHCP server setup, also required for PXE
+booting, are discussed in an earlier chapter.)
 
 .. NOTE::
 

--- a/docs/user_guide/PXE_Boot.rst
+++ b/docs/user_guide/PXE_Boot.rst
@@ -29,39 +29,53 @@ This section describes how to configure the kickstart server.
 
 #. Locate the following files in the ``/var/www/ks`` directory
 
-   -  ``pupclient_x86_64.cfg``
-   -  ``diskdetect.sh``
+   -  ``pupclient_x86_64.cfg``: Example client kickstart configuration script.
+   -  ``diskdetect.sh``:  Example script to determine disks available
+      on a system and then apply disk configuration.  This script is used
+      by ``pupclient_x86_64.cfg``.
 
-#. Open each of the files and follow the instructions provided within them to
-   replace the variables.  You need to know the IP Addresses of the YUM,
-   Kickstart, and TFTP servers. (They default to the SIMP server in
-   ``simp config``).  You may need to make several copies of this file depending
-   on the different configurations of your clients.
+#. Open the ``pupclient_x86_64.cfg`` file and follow the instructions provided
+   within it to replace the variables listed and to customize for
+   :term:`BIOS`/:term:`UEFI` boot and/or FIPS/non-FIPS mode.  If you have servers
+   that require different boot mode or FIPS options, you will need to make make
+   customized copies of this file to provide those distinct configurations. You
+   will also have to configure TFTP to point to the appropriate files.
 
-   - ``pupclient_x86_64.cfg``: Replace the variables noted at the top and
-     generate and enter the passwords.
-     You  need to set up separate files for clients that will be booting in UEFI
-     mode as opposed to Legacy (BIOS) mode.  There are also different files for
-     SysVinit systems and systemd systems.
+   - Instructions are provided both at the top of the file and throughout the
+     body of the file.
+   - You need to know the IP Addresses of the YUM, Kickstart, and TFTP servers.
+     (They default to the SIMP server in ``simp config``).
+   - Use the commands described in the comments at the top of the file to
+     generate the root and grub passwords hashes.  Be sure to replace ``password``
+     with your root password.
+   - Follow the instructions throughout the file to customize for BIOS/UEFI boot.
+   - Follow the instructions throughout the file to customize for FIPS/non-FIPS
+     mode.
 
-   - ``diskdetect.sh``:  The ``diskdetect.sh`` script is responsible for
-     detecting the first active disk and applying a disk configuration. Edit
-     this file to meet any necessary requirements or use this file as a
-     starting point for further work. It will work as is for most systems as
-     long as your disk device names are in the list.
-
-.. NOTE:
-
-   In SIMP 6.2 UEFI PXE boot was automated.  UEFI and Legacy boot modes require
-   different ``bootloader`` lines in the kickstart file.  You will need to create
-   separate kickstart files if you wish to boot systems in both modes and point to
-   the correct one in the linux model you create for it in the .
+#. Open the ``diskdetect.sh`` script and customize the disk device names and/or
+   partitions as appropriate for your site.  The sample ``diskdetect.sh`` script
+   will work, as is, for most systems, as long as your disk device names are in the
+   list.  In addition, the sample script provides STIG-compliant partitioning.
 
 #. Type ``chown root.apache /var/www/ks/*`` to ensure that all files are owned
    by ``root`` and in the ``apache`` group.
 
 #. Type ``chmod 640 /var/www/ks/*`` to change the permissions so the owner can
    read and write the file and the ``apache`` group can only read.
+
+.. NOTE::
+
+   Two major changes were made to ``pupclient_x86_64.cfg`` in SIMP 6.2:
+
+   - UEFI PXE support was added.
+   - To address timeout issues that caused Puppet bootstrap failures, the use of
+     the ``runpuppet`` script to bootstrap Puppet on the client was replaced
+     with the use of two scripts, both provided by the ``simp::server::kickstart``
+     class:
+
+     - A ``systemd`` unit file for CentOS 7 (``simp_client_bootstrap.service``)
+       or a ``systemv`` init script for CentOS 6 (``simp_client_bootstrap``).
+     - A common bootstrap script (``bootstrap_simp_client``) used by both.
 
 .. NOTE::
 
@@ -88,10 +102,12 @@ This section describes the process of setting up static files and manifests for
 :term:`TFTP`.
 
 .. NOTE::
-  The tftp root directory was changed in SIMP 6.2.  In previous versions it was
-  ``/tftproot``, and in 6.2 and later it is ``/var/lib/tftpboot``.  If you are upgrading
-  to 6.2 from a prior release and wish the files to remain in the ``/tftpboot`` directory
-  set ``tftpboot::tftpboot_root_dir`` to ``/tftpboot`` in :term:`Hiera`.
+
+  The tftp root directory was changed in SIMP 6.2 to conform to DISA STIG
+  standards.  In previous versions it was ``/tftpboot``, and in 6.2 and later
+  it is ``/var/lib/tftpboot``.  If you are upgrading to 6.2 from a prior
+  release and wish the files to remain in the ``/tftpboot`` directory, set
+  ``tftpboot::tftpboot_root_dir`` to ``/tftpboot`` in :term:`Hiera`.
 
 Static Files
 ^^^^^^^^^^^^
@@ -110,8 +126,8 @@ Under the linux-install directory you should find a directory named
 
 Under OSTYPE-MAJORRELEASE.MINORRELEASE-ARCH you should find the files:
 
-* initrd.img
-* vmlinuz
+* ``initrd.img``
+* ``vmlinuz``
 
 If these are not there then you must create the directories as needed and copy
 the files from ``/var/www/yum/<OSTYPE>/<MAJORRELEASE>/<ARCH>/images/pxeboot``
@@ -125,7 +141,7 @@ the resources in the tftpboot.pp manifest examples.
    to kickstart machines, you must also upgrade the images in the tftp directory.
    If they do not match you can get an error such as "unknown file system type 'xfs'"
 
-Next you need to set up the boot files for either legacy boot mode, UEFI mode, or both.
+Next you need to set up the boot files for either BIOS boot mode, UEFI mode, or both.
 
 .. NOTE::
 
@@ -142,10 +158,10 @@ files to model different systems.
 1. Create the file
    ``/etc/puppetlabs/code/environments/simp/modules/site/manifests/tftpboot.pp``.
    This file will contain linux models for different types of systems and
-   a list mac addresses assigned to that model.
+   a mapping of MAC addresses to each model.
 
    Use the source code example below.  Linux model examples are given for
-   CentOS 6 and 7 using both UEFI and legacy boot mode.
+   CentOS 6 and 7 using both UEFI and BIOS boot mode.
 
    * Replace ``KSSERVER`` with the IP address of kickstart server (or the code
      to look up the IP Address using :term:`Hiera`).
@@ -156,11 +172,11 @@ files to model different systems.
    * ``MODEL NAME`` is usually of the form ``OSTYPE-MAJORRELEASE-ARCH`` for
      consistency.
 
-   * You will need to know what kickstart file you are using.  UEFI and Legacy mode
+   * You will need to know what kickstart file you are using.  UEFI and BIOS mode
      require separate kickstart files.  Other things that might require a different
-     kickstart file to be configure are disk drive configurations and FIPS configuration.
-     Create a different linux model file for each different kickstart file needed.
-
+     kickstart file to be configure are disk drive configurations and FIPS
+     configuration.  Create a different linux model file for each different
+     kickstart file needed.
 
 .. code-block:: ruby
 
@@ -168,7 +184,7 @@ files to model different systems.
      include '::tftpboot'
 
      #--------
-     # LEGACY MODE EXAMPLES
+     # BIOS MODE MODEL EXAMPLES
 
      # for CentOS/RedHat 7 Legacy/BIOS boot
      tftpboot::linux_model { 'el7_x86_64':
@@ -188,13 +204,13 @@ files to model different systems.
      }
 
      #------
-     # UEFI MODE EXAMPLES
+     # UEFI MODE MODEL EXAMPLES
 
-     # NOTE UEFI boot uses the linux_model_efi module.
-     # You also would use a different kickstart file because the bootloader command
-     # is different.  Read the instructions
-     # in the pupclient_x86_64 file and make sure you have the correct bootloader
-     # line.
+     # NOTE UEFI boot uses the linux_model_efi module and has different
+     # `extra` arguments.  You also would use a different kickstart file
+     # because the bootloader command within the kickstart file is
+     # different.  Read the instructions in the default pupclient_x86_64.cfg
+     # file and make sure you have the correct bootloader line.
      #
      # For CentOS/RedHat 7 UEFI boot
      tftpboot::linux_model_efi { 'el7_x86_64_efi':
@@ -215,14 +231,23 @@ files to model different systems.
      }
 
      #------
-     # All systems need the following
+     # DEFAULT HOST BOOT CONFIGURATION EXAMPLES
+
+     # If desired, create defaults boot configuration for BIOS and UEFI.
+     # Note that the name of the default UEFI configuration file needs
+     # to be 'grub.cfg'.
+     tftpboot::assign_host { 'default': model => 'el7_x86_64' }
+     tftpboot::assign_host_efi { 'grub.cfg': model => 'el7_x86_64_efi' }
+
+
+     #------
+     # HOST BOOT CONFIGURATION ASSIGNMENT EXAMPLES
 
      # For each system define what module you want to use by pointing
-     # its macaddress to the appropriate model.  Note that the macaddress
-     # is preceded by ``01-``.
-     tftpboot::assign_host { 'default': model => 'el7_x86_64' }
-     tftpboot::assign_host { 01-aa-bb-cc-dd-00-11: model => 'el7_x86_64_efi' }
+     # its MAC address to the appropriate model.  Note that the MAC
+     # address is preceded by ``01-``.
      tftpboot::assign_host { 01-aa-ab-ac-1d-05-11: model => 'el6_x86_64' }
+     tftpboot::assign_host_efi { 01-aa-bb-cc-dd-00-11: model => 'el7_x86_64_efi' }
    }
 
 
@@ -244,15 +269,15 @@ files to model different systems.
 
 .. NOTE::
 
-   To PXE boot more OSs, create, in the tftpboot.pp file, a
-   ``tftpboot::linux_model`` block for each OS type using the extra directories
-   and kickstart files created using the notes in previous sections. Point
-   individual systems to them by adding assign_host lines with their MAC
-   pointing to the appropriate model name.
+   To provide PXE boot configuration for more OSs, create, in the ``tftpboot.pp``
+   file, a ``tftpboot::linux_model`` or ``tftpboot::linux_model_efi`` block for
+   each OS type. Then, assign individual hosts to each model by adding
+   ``tftpboot::assign_host`` or ``tftpboot::assign_host_efi`` resources.
 
-Lastly, make sure DHCP is set up correctly.  In SIMP 6.2 the DHCP template was updated to
-include a test for architecture type.  These changes are needed if you booting
-UEFI systems.
+Lastly, make sure DHCP is set up correctly.  In SIMP 6.2 the example ``dhcpd.conf``
+was updated to determine the appropriate boot loader file to use, depending upon
+the boot mode of the PXE client.  These changes are needed if you booting UEFI
+systems.
 
 For more information see the `RedHat 6 PXE`_ or `RedHat 7 PXE`_ Installation Guides.
 

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
@@ -11,49 +11,63 @@ Upgrading from SIMP-6.1.0 to SIMP-6.2.0
 Update kickstart files
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The kickstart example file, pupclient_x86_64.cfg,  was updated.  Changes in this
+The kickstart example file, ``pupclient_x86_64.cfg``,  was updated.  Changes in this
 file should be used to create any new kickstart files and backported to any existing
-kickstart files.
-The new templatescan be found in the simp core module under
-build/distributions/<OS>/<OS Major Vesrion>/<Architecture>/DVD/ks.
+kickstart files.  The new, OS-specific versions of this file are included in the
+SIMP-6.2.0 ISOs, but may also be found in the `simp-core repository`_ under
+``build/distributions/<OS>/<OS Major Version>/<Architecture>/DVD/ks``.
 
-Two changes were made:
+Two major changes were made:
 
-#. It was discovered that, on particularly loaded systems, the init script may
-   be killed by systemd on EL7 for running for more than 5 minutes.  The core runpuppet
-   capability was split out and an init script is added to EL6 and a systemd unit file
-   is added to EL7.  The kickstart file was updated to download both of these files, the
-   runpuppet file and the appropriate service file.  Code was also added to configure
-   enable the service.  You  need separate kickstart files
-   for CentOS 6 and CentOS 7 systems.
+#. To solve two timeout problems on particularly loaded systems, both of which
+   caused client Puppet bootstrapping to fail and require manual intervention,
+   the ``runpuppet`` script was completely rewritten.  Although ``runpuppet`` is
+   still available, it is deprecated and has been replaced with a pair of scripts:
 
-#. UEFI PXE booting was configured and tested in SIMP 6.2.  The pupclient template
-   was updated to include instructions for changing the file to accomodate UEFI
-   boot.  Also, an error in the configation file that prevented UEFI systems from
-   booting correctly was fixed.
+     - A ``systemd`` unit file for CentOS 7 (``simp_client_bootstrap.service``)
+       or a ``systemv`` init script for CentOS 6 (``simp_client_bootstrap``).
+     - A common bootstrap script (``bootstrap_simp_client``) used by both.
+
+   The use of an actual ``systemd`` unit file for CentOS 7 solved the problem in
+   which ``systemd`` on CentOS 7 was killing ``runpuppet``, when it ran longer
+   than 5 minutes.  By default, setting the static hostname of the client on
+   CentOS 7 at the beginning of the client Puppet bootstrap process solved
+   the problem whereby the DHCP lease may expire in the middle of bootstrapping,
+   resulting in ``localhost`` being erroneously used for the client hostname
+   within generated Puppet configuration.
+
+   The sample kickstart files for CentOS 6 and CentOS 7 were updated to download
+   the appropriate pair of files, and then enable the service at boot.
+
+#. The sample client kickstart file, ``pupclient_86_64.cfg``, was updated to
+   include instructions for changing the file to accomodate UEFI boot.  Also,
+   an error in that configuration file that prevented UEFI systems from booting
+   was fixed.
 
 Update dhcpd.conf
 ^^^^^^^^^^^^^^^^^
 
-Changes were added to the ``dhcpd.conf`` file  that enable the DHCP server to determine
-what mode, Legacy or UEFI, a system is kickstarting in and send the appropriate tftp
-directory to boot from.
+Changes were added to the ``dhcpd.conf`` file  that enable the DHCP server to
+determine what mode, BIOS or UEFI, a system is kickstarting in and then to set
+the appropriate boot loader file on the TFTP server.
 
-In a default puppet system the dhcpd.conf file is copied from rsync. The  new file
-can be found in the ``simp-rsync-skeleton`` module under
-``environments/simp/rsync/RedHat/Global/dhcpd``.  Look at this file for the changes
-and update the ``dhcpd.conf file in the appropriate rsync directory.  The rsync
-root is /var/simp/environments/<environment name>/rsync.
+On a SIMP server, the example ``dhcpd.conf`` file is installed in
+``/var/simp/environments/simp/RedHat/Global/dhcpd/dhcpd.conf`` via the
+``simp-rsync`` package. This file may also be found in the
+`simp-rsync-skeleton repository`_ under
+``environments/simp/rsync/RedHat/Global/dhcpd``.
 
 Update the TFTP root directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default TFTP root directory was changed to ``/var/lib/tftpboot``.  To continue using
-``/tftpboot`` set ``tftpboot::tftpboot_root_dir``  in hiera to ``/tftpboot``.
-Alternately, to use the new directory, copy any files not maintained in rsync
-to the new directory.  Make sure the permissions, including selinux context, are correct.
+The default TFTP root directory was changed to ``/var/lib/tftpboot`` to
+conform to DISA STIG standards.  To continue using ``/tftpboot`` set
+``tftpboot::tftpboot_root_dir`` in hiera to ``/tftpboot``.  Alternately, to use
+the new directory, copy any files not managed by the ``rsync`` module (i.e., not
+stored in ``/var/simp/environments/<environment>/rsync/<OS>/Global/tftpboot``)
+to the new directory.  Make sure the permissions, including selinux context, are
+correct. TFTP boot will fail to find boot files that have the incorrect selinux
+context.
 
-Unless ``/tftproot`` is a seperately mounted partition, the tftp files existed in
-the root partition.  The new directory, besides being the default used by RedHat, also
-does not reside in the root partition if the system is partitioned according to STIG
-standards.
+.. _simp-core repository: https://github.com/simp/simp-core
+.. _simp-rsync-skeleton repository: https://github.com/simp/simp-rsync-skeleton

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
@@ -1,0 +1,59 @@
+.. _upgrade-6.1.0-to-6.2.0:
+
+Upgrading from SIMP-6.1.0 to SIMP-6.2.0
+---------------------------------------
+
+.. IMPORTANT::
+
+   It is *highly recommended* that you read the information in this section
+   in its entirety.
+
+Update kickstart files
+^^^^^^^^^^^^^^^^^^^^^^
+
+The kickstart example file, pupclient_x86_64.cfg,  was updated.  Changes in this
+file should be used to create any new kickstart files and backported to any existing
+kickstart files.
+The new templatescan be found in the simp core module under
+build/distributions/<OS>/<OS Major Vesrion>/<Architecture>/DVD/ks.
+
+Two changes were made:
+
+#. It was discovered that, on particularly loaded systems, the init script may
+   be killed by systemd on EL7 for running for more than 5 minutes.  The core runpuppet
+   capability was split out and an init script is added to EL6 and a systemd unit file
+   is added to EL7.  The kickstart file was updated to download both of these files, the
+   runpuppet file and the appropriate service file.  Code was also added to configure
+   enable the service.  You  need seperate kickstart files
+   for CentOS 6 and CentOS 7 systems.
+
+#. UEFI PXE booting was configured and tested in SIMP 6.2.  The pupclient template
+   was updated to include instructions for changing the file to accomodate UEFI
+   boot.  Also, an error in the config file that prevented UEFI systems from
+   booting correctly was fixed.
+
+Update dhcpd.conf
+^^^^^^^^^^^^^^^^^
+
+Changes were added to the ``dhcpd.conf`` file  that enable the DHCP server to determine
+what mode, Legacy or UEFI, a system is kickstarting in and send the appropiate tftp
+directory to boot from.
+
+In a default puppet system the dhcpd.conf file is copied from rsync. The  new file
+can be found in the ``simp-rsync-skeleton`` module under
+``environments/simp/rsync/RedHat/Global/dhcpd``.  Look at this file for the changes
+and update the ``dhcpd.conf file in the appropriate rsync directory.  The rsync
+root is /var/simp/environments/<environment name>/rsync.
+
+Update the TFTP root directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default TFTP root directory was changed to ``/var/lib/tftpboot``.  To continue using
+``/tftpboot`` set ``tftpboot::tftpboot_root_dir``  in hiera to ``/tftpboot``.
+Alternately, to use the new directory, copy any files not maintained in rsync
+to the new directory.  Make sure the permissions, including selinux context, are correct.
+
+Unless ``/tftproot`` is a seperately mounted partition, the tftp files existed in
+the root partion.  The new directory, besides being the default used by RedHat, also
+does not reside in the root partition if the system is partitioned according to STIG
+standards.

--- a/docs/user_guide/Upgrade_SIMP/Version_Specific_Upgrade_Instructions.rst
+++ b/docs/user_guide/Upgrade_SIMP/Version_Specific_Upgrade_Instructions.rst
@@ -1,4 +1,5 @@
 Version-Specific Upgrade Instructions
 =====================================
 
+.. include:: Version_Maps/6.1.0_6.2.0.inc
 .. include:: Version_Maps/6.0.0_6.1.0.inc


### PR DESCRIPTION
  -This updates the docs for UEFI PXE booting.
  -It adds an upgrade section for 6.1.0 - 6.2.0 and documents files
  that need to be updated in and existing system.
  -Renames For he IMpatient to Quick Start

SIMP-5106 #close
SIMP-5107 #close
SIMP-4557 #close