### PR TITLE
(SIMP-2986) Update Packages in Documentation

### DIFF
--- a/docs/user_guide/SIMP_Package_Data.rst
+++ b/docs/user_guide/SIMP_Package_Data.rst
@@ -43,6 +43,6 @@ To find the particular package list for your version of SIMP, you can go to:
 
 ``https://github.com/simp/simp-core/blob/<version>/build/distributions/<os>/<os_version>/<arch>/yum_data/packages.yaml``
 
-So, if you're using SIMP 6.0.0 on CentOS 6 and an x86_64 architecture, you would navigate to:
+So, if you're using SIMP 6.0.0-0 on CentOS 6 and an x86_64 architecture, you would navigate to:
 
-``https://github.com/simp/simp-core/blob/6.0.0/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml``
+``https://github.com/simp/simp-core/blob/6.0.0-0/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml``


### PR DESCRIPTION
-  The documentation was fixed to referred to how extract the package
   list previously so this is OBE.  I just fixed a broken link in
   in the page.
SIMP-2986 #close
SIMP-5290 #close