### PR TITLE
Fix incorrect path for NFS server export

### DIFF
--- a/docs/user_guide/HOWTO/NFS.rst
+++ b/docs/user_guide/HOWTO/NFS.rst
@@ -319,7 +319,7 @@ the manifest is called nfs_server.pp.
      } else {
          nfs::server::export { 'share1':
          clients     => ['127.0.0.1'],
-         export_path => "${data_dir}/nfs/exports/home",
+         export_path => "${data_dir}/nfs/exports/share1",
          rw          => true,
          sec         => $sec,
          insecure    => true


### PR DESCRIPTION
When following these instructions I noticed that the export path for the example share with stunnel was incorrectly pointing to `/home` instead of `/share1` which confused me for a moment. I tested it out and it seems to me that it is in fact incorrect.