### PR TITLE
(SIMP-4546) Document unavoidable `ca` warning

### DIFF
--- a/docs/user_guide/Troubleshooting.rst
+++ b/docs/user_guide/Troubleshooting.rst
@@ -11,4 +11,5 @@ How to troubleshoot common problems that occur when installing and using SIMP.
   Troubleshooting/My_Services_Are_Dying
   Troubleshooting/Why_Cant_I_Login
   Troubleshooting/PKI_Validation
+  Troubleshooting/Puppet_Issues
   Troubleshooting/Puppet_Certificate_Issues

--- a/docs/user_guide/Troubleshooting/Puppet_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Issues.rst
@@ -33,6 +33,7 @@ in a harmless—but unavoidable—deprecation warning whenever ``puppet`` is run
 on Puppet masters configured to `not` act as the Puppet CA
 (``pupmod::master::enable_ca: false``):
 ::
+
     Warning: Setting ca is deprecated.
     (location: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/settings.rb:1169:in 'issue_deprecation_warning')
 

--- a/docs/user_guide/Troubleshooting/Puppet_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Issues.rst
@@ -6,7 +6,7 @@ Puppet Issues
 
 .. _ug-ts-puppet-depwarnings:
 
-Puppet Deprecation warnings
+Puppet Deprecation Warnings
 ---------------------------
 
 Puppet 5 has added deprecation warnings to several settings.  If one of these

--- a/docs/user_guide/Troubleshooting/Puppet_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Issues.rst
@@ -44,7 +44,7 @@ Disabling `all` Puppet deprecation warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you are encountering an unavoidable deprecation warning and find it
-unacceptable, you can hide from your ``puppet`` runs by disabling `all`
+unacceptable, you can suppress such warnings during your ``puppet`` runs by disabling `all`
 deprecation warnings:
 
 .. WARNING::

--- a/docs/user_guide/Troubleshooting/Puppet_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Issues.rst
@@ -1,0 +1,76 @@
+.. _ug-puppet-issues:
+
+Puppet Issues
+=============
+
+
+.. _ug-ts-puppet-depwarnings:
+
+Puppet Deprecation warnings
+---------------------------
+
+Puppet 5 has added deprecation warnings to several settings.  If one of these
+settings is present in a host's ``puppet.conf``, you may see warnings at the
+beginning of every ``puppet`` run like this:
+::
+
+    Warning: Setting configprint is deprecated.
+    (location: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/settings.rb:1169:in 'issue_deprecation_warning')
+
+These messages are innocuous.  The deprecated settings can still be used until
+Puppet 6.
+
+SIMP's ``pupmod`` module usually manages its settings in ``puppet.conf``
+without using deprecated settings.  However, under some circumstances it has no
+other choice, resulting in unavoidable error messages.
+
+
+``Warning: Setting ca is deprecated.``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``[master] ca`` is marked as deprecated from Puppet 5.5.6 onward.  This results
+in a harmless—but unavoidable—deprecation warning whenever ``puppet`` is run
+on Puppet masters configured to `not` act as the Puppet CA
+(``pupmod::master::enable_ca: false``):
+::
+    Warning: Setting ca is deprecated.
+    (location: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/settings.rb:1169:in 'issue_deprecation_warning')
+
+
+
+.. _ug-ts-puppet-disabling-depwarnings:
+
+Disabling `all` Puppet deprecation warnings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are encountering an unavoidable deprecation warning and find it
+unacceptable, you can hide from your ``puppet`` runs by disabling `all`
+deprecation warnings:
+
+.. WARNING::
+
+   **This will disable all deprecation warnings**.  If new settings are deprecated
+   in future releases, you will not see warnings about them. This is
+   particularly important if you manage additional ``puppet.conf`` settings.
+   Use with caution!
+
+.. code-block:: puppet
+
+   pupmod::conf { 'disable_all_deprecation_warnings':
+     section => 'main',
+     setting => 'disable_warnings',
+     value   => 'deprecations',
+     confdir => $facts['puppet_settings']['main']['confdir'],
+     notify  => Service[puppetserver],
+     ensure  => present,
+   }
+
+This will ensure the following setting in ``puppet.conf``:
+
+.. code-block:: ini
+
+  [main]
+  disable_warnings = deprecations
+
+If you want to enable deprecation warnings again, change ``ensure => present`` to ``ensure =>
+absent``.

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.2.0_6.3.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.2.0_6.3.0.inc
@@ -11,6 +11,7 @@ Possible warnings when running ``puppet``
    Puppet CAs (``pupmod::master::enable_ca: false``) will display a
    deprecation warning whenever ``puppet`` is run:
    ::
+   
        Warning: Setting ca is deprecated.
        (location: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/settings.rb:1169:in `issue_deprecation_warning')
 

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.2.0_6.3.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.2.0_6.3.0.inc
@@ -1,0 +1,19 @@
+.. _upgrade-6.2.0-to-6.3.0:
+
+Upgrading from SIMP-6.2.0 to SIMP-6.3.0
+---------------------------------------
+
+Possible warnings when running ``puppet``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. NOTE::
+
+   After upgrading to ``puppet-agent`` 5.5.6+, Puppet masters that are `not`
+   Puppet CAs (``pupmod::master::enable_ca: false``) will display a
+   deprecation warning whenever ``puppet`` is run:
+   ::
+       Warning: Setting ca is deprecated.
+       (location: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/settings.rb:1169:in `issue_deprecation_warning')
+
+   This message is innocuous, but unavoidable unless you are comfortable
+   with :ref:`ug-ts-puppet-disabling-depwarnings`.
+

--- a/docs/user_guide/Upgrade_SIMP/Version_Specific_Upgrade_Instructions.rst
+++ b/docs/user_guide/Upgrade_SIMP/Version_Specific_Upgrade_Instructions.rst
@@ -3,5 +3,6 @@
 Version-Specific Upgrade Instructions
 =====================================
 
+.. include:: Version_Maps/6.2.0_6.3.0.inc
 .. include:: Version_Maps/6.1.0_6.2.0.inc
 .. include:: Version_Maps/6.0.0_6.1.0.inc


### PR DESCRIPTION
Puppet 5.5.6+ marks the `[master]` section's `ca` setting as deprecated,
causing every `puppet` run to emit an eye-catching warning when the
configuration is set in `puppet.conf`.  **simp/pupmod** has been updated
to accomodate this, but in some circumstances it is unavoidable.

This patch documents the issue, provides a (heavy-handed) workaround, and
draws attention to it in the 6.3.0 upgrade guide.

SIMP-5456 #close