### PR TITLE
(SIMP-MAINT) Fix code block for 6.3.0-0 Errata

### DIFF
--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -55,10 +55,8 @@ users disable the feature by setting
 
 If using a default SIMP installation, this can be done easily by running the
 following commands as root:
-
-```
-echo 'pupmod::master::generate_types::enable: false' >> /etc/puppetlabs/code/environments/production/data/default.yaml
-```
+`cd /etc/puppetlabs/code/environments/production/data`
+`echo 'pupmod::master::generate_types::enable: false' >> ./default.yaml`
 
 For more information on the bug and the current status,
 please visit `SIMP-5974`_. 


### PR DESCRIPTION
- Fix code block in SIMP-6.3.0-0 errata to prevent overextended code
block and extra whitespace/characters