### PR TITLE
(SIMP-MAINT) Fix code block in errata

### DIFF
--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -55,9 +55,11 @@ users disable the feature by setting
 
 If using a default SIMP installation, this can be done easily by running the
 following commands as root:
-`cd /etc/puppetlabs/code/environments/production/data`
-`echo 'pupmod::master::generate_types::enable: false' >> ./default.yaml`
 
+.. code-block:: bash
+
+  echo 'pupmod::master::generate_types::enable: false' >> /etc/puppetlabs/code/environments/production/data/default.yaml
+  
 For more information on the bug and the current status,
 please visit `SIMP-5974`_. 
 


### PR DESCRIPTION
- updates italics (should have been double backticks for code line) to a code block for better appearance. 