### PR TITLE
(SIMP-6323 ) Fixed typo in Prepare SIMP ldifs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 21 2019 Jim Anderson <thesemicolons@protonmail.com>
+- Fixed typo in Prepare SIMP ldifs.
+  - sed command had escaped asterisk, should be unescaped.
+
 * Fri Feb 22 2019 Trevor Vaughan <tvaughan@onyxpoint.com>
 - Updates for the 6.3.3 release
   - Changelog update

--- a/docs/user_guide/User_Management/LDAP.rst
+++ b/docs/user_guide/User_Management/LDAP.rst
@@ -19,7 +19,7 @@ Copy these files into ``/root/ldifs`` and fix their Distinguished Names:
    # mkdir /root/ldifs
    # cp /usr/share/simp/ldifs/* /root/ldifs
    # cd /root/ldifs
-   # sed -i 's/dc=your,dc=domain/<your actual DN information>/g' \*.ldif
+   # sed -i 's/dc=your,dc=domain/<your actual DN information>/g' *.ldif
 
 .. WARNING::
    Do not leave any extraneous spaces in LDIF files!


### PR DESCRIPTION
sed command in 4.8.1.1 Prepare SIMP ldifs had an escaped asterisk. The
command errors with: "sed: can't read *.ldif: No such file or
directory" when run this way. The command runs find with an unescaped
asterisk.