### PR TITLE
(SIMP-6328) Added official hardware requirement for RAM plus swap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 * Mon Mar 25 2019 Jim Anderson <thesemicolons@protonmail.com>
+- Added official hardware requirement of  3.4 GB of RAM + swap.
 - Managing Local/Service Users had an incomplete path for
   local_account.pp and service_account.pp.
 

--- a/docs/getting_started_guide/System_Requirements.rst
+++ b/docs/getting_started_guide/System_Requirements.rst
@@ -12,8 +12,15 @@ including:
 * Number of modules in your module path
 * Amount of hieradata
 
-While there are no official `hardware requirements`_, we recommend the
-following **for your SIMP server**:
+Official `hardware requirements` **for your SIMP server**:
+
+* At least 3.4 GB of RAM + swap.
+
+With less than 3.4 GB it is possible for either the puppet database or
+puppet server to not start.
+
+We recommend the following `hardware requirements` **for your SIMP
+server**:
 
 * **2** CPUs and **6 GB** of RAM, at a minimum
 * **2 - 4** CPUs and **10 GB** of RAM to serve up to *1,000* nodes


### PR DESCRIPTION
With less than 3.4 GB of RAM+swap the puppet database and puppet server
may not start. /etc/sysconfig/puppetdb requires 1516m and
/etc/sysconfig/puppetserver requires 1896m. This comes out to just over
3.3 GB.

If -Xms is lowered, it is possible to have a machine with less than 3.4
GB of RAM+swap, but performance will be impacted, and at some point
there will be too little allocated memory for the puppet database/server
to run.