### PR TITLE
(SIMP-6330) Incomplete path for saving account.pp files.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 25 2019 Jim Anderson <thesemicolons@protonmail.com>
+- Managing Local/Service Users had an incomplete path for
+  local_account.pp and service_account.pp.
+
 * Thu Mar 21 2019 Jim Anderson <thesemicolons@protonmail.com>
 - Fixed typo in Prepare SIMP ldifs.
   - sed command had escaped asterisk, should be unescaped.

--- a/docs/user_guide/User_Management/Local_Users.rst
+++ b/docs/user_guide/User_Management/Local_Users.rst
@@ -13,7 +13,8 @@ SIMP.
 The following examples assume that you are using the ``site`` module to manage
 site-specific puppet manifests. The examples may easily be extrapolated into
 defined types if you wish but are presented as classes for simplicity. Save the
-files below in ``/etc/puppetlabs/code/environments/simp/modules/site/`` as
+files below in
+``/etc/puppetlabs/code/environments/simp/modules/site/manifests/`` as
 ``local_account.pp`` and ``service_account.pp``, ensuring the correct ownership,
 group, and permissions.
 


### PR DESCRIPTION
The Managing Local/Service Users page indicated to save the account.pp
files in /etc/puppetlabs/code/environments/simp/modules/site/. This path
is incomplete and needs manifests/ at the end.