### PR TITLE
(SIMP-6363) Refactor references to the 'site' mod

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * Mon Apr 01 2019 Trevor Vaughan <tvaughan@onyxpoint.com>
 - Removed all calls to the 'site' module specifically
-- Rebranded references to the 'site' module as a convienient place holder and
+- Rebranded references to the 'site' module as a convenient place holder and
   added appropriate glossary terms.
 - Added glossary terms for:
   - Puppet Module

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,20 @@
+* Mon Apr 01 2019 Trevor Vaughan <tvaughan@onyxpoint.com>
+- Removed all calls to the 'site' module specifically
+- Rebranded references to the 'site' module as a convienient place holder and
+  added appropriate glossary terms.
+- Added glossary terms for:
+  - Puppet Module
+  - Puppet Namespace
+  - Site Profile
+
 * Fri Mar 29 2019 Jim Anderson <thesemicolons@protonmail.com>
 - Added a page under Installation Advanced Topics regarding disk
   partitioning.
 - Modified Transmission Confidentiality and Integrity to update location
   for location of certificates.
-
-* Mon Mar 25 2019 Jim Anderson <thesemicolons@protonmail.com>
 - Added official hardware requirement of  3.4 GB of RAM + swap.
 - Managing Local/Service Users had an incomplete path for
   local_account.pp and service_account.pp.
-
-* Thu Mar 21 2019 Jim Anderson <thesemicolons@protonmail.com>
 - Fixed typo in Prepare SIMP ldifs.
   - sed command had escaped asterisk, should be unescaped.
 

--- a/docs/getting_started_guide/Installation_Options/ISO/Installation_Advanced_Topics/Disk_Partitioning.rst
+++ b/docs/getting_started_guide/Installation_Options/ISO/Installation_Advanced_Topics/Disk_Partitioning.rst
@@ -1,7 +1,7 @@
 .. _ig-disk-partitioning:
 
 Disk Partitioning
----------------
+-----------------
 
 The default SIMP installation has a disk partitioning scheme that is
 designed to meet multiple compliance and system hardening standards and

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -692,7 +692,7 @@ Glossary of Terms
       :term:`Puppet Module` that is specific to your site. This simply allows
       for a common isolated :term:`Puppet namespace` to reduce confusion in the
       documentation. You could add a module literally called ``site`` to your
-      environment which would make the examples generally able to be copy and
+      environment which would make the examples generally able to be copied and
       pasted into files in the new module.
 
       You may see various shorthand code snippets that refer to

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -514,10 +514,9 @@ Glossary of Terms
       ``puppet`` application.
 
    Puppet Namespace
-      A unique identification mechanism used by the ``puppet`` compiler to
-      uniquely identify code during compilation. Generally, namespaces align
-      with :term:`Puppet Module` file paths and are separated by two colons at
-      each directory.
+      A mechanism used by the ``puppet`` compiler to uniquely identify code
+      during compilation. Generally, namespaces align with :term:`Puppet Module` 
+      file paths and are separated by two colons at each directory.
 
       See: `Namespaces and Autoloading <https://puppet.com/docs/puppet/latest/lang_namespaces.html>`__
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -499,7 +499,7 @@ Glossary of Terms
       See: `Environments: <https://puppet.com/docs/puppet/latest/environments_about.html>`__
 
    Puppetfile
-      A Ruby file that contains references to Puppet modules.
+      A Ruby file that contains references to :term:`Puppet modules`.
 
       See the Puppetfile spec: https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd
 
@@ -507,6 +507,19 @@ Glossary of Terms
       For the purposes of this document, this is the Server upon which the
       :term:`puppetserver` process is running and to which your clients
       connect.
+
+   Puppet Module
+   Puppet Modules
+      A self-contained bundle of code and data able to be processed by the
+      ``puppet`` application.
+
+   Puppet Namespace
+      A unique identification mechanism used by the ``puppet`` compiler to
+      uniquely identify code during compilation. Generally, namespaces align
+      with :term:`Puppet Module` file paths and are separated by two colons at
+      each directory.
+
+      See: `Namespaces and Autoloading <https://puppet.com/docs/puppet/latest/lang_namespaces.html>`__
 
    Puppet Resource
    Puppet Resources
@@ -654,7 +667,7 @@ Glossary of Terms
 
    SIMP Compliance Engine
       A SIMP component that adds the capability to evaluate your
-      :term:`Puppet` code for compilance with a policy as well as enforcing
+      :term:`Puppet` code for compliance with a policy as well as enforcing
       that the code enacts the specified policy.
 
       See: `SIMP Compliance Engine Repository <https://github.com/simp/pupmod-simp-compliance_markup>`__
@@ -673,6 +686,32 @@ Glossary of Terms
      <ENVIRONMENTS DIRECTORY>/<ENVIRONMENT>/manifests.
 
      Source: `Puppet Documentation: Main manifest directory <https://puppet.com/docs/puppet/5.5/dirs_manifest.html>`__
+
+   Site Profile
+      This term is used throughout the documentation to refer to a
+      :term:`Puppet Module` that is specific to your site. This simply allows
+      for a common isolated :term:`Puppet namespace` to reduce confusion in the
+      documentation. You could add a module literally called ``site`` to your
+      environment which would make the examples generally able to be copy and
+      pasted into files in the new module.
+
+      You may see various shorthand code snippets that refer to
+      ``site::<name>``. This indicates that the class should be created
+      somewhere specific to your site and does not dictate the naming of the
+      class.
+
+      When referred to by path, the path will start at the ``modules``
+      directory for easy reference. This should be expanded to the target
+      :term:`Puppet environment` path.
+
+      The following code snippet can be used to determine your module path.
+
+      .. code-block:: bash
+
+         $env_path=`puppet config print environmentpath`
+         $env=`puppet config print environment`
+
+         echo "${env_path}/${env}/modules/site"
 
    Spectre
       A vulnerability that affects modern microprocessors that perform branch

--- a/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
+++ b/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
@@ -137,7 +137,7 @@ profile to all workstations is to use the SIMP ``hostgroup`` :term:`Hiera`
 configuration capability.
 
 To do use ``hostgroups``, you will need to edit the ``site.pp`` in the target
-environment's :term:`site manifest`.
+:term:`puppet environment` :term:`site manifest`.
 
 Adding the following to
 ``/etc/puppetlabs/code/environments/simp/manifests/site.pp`` will will make all

--- a/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
+++ b/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
@@ -133,10 +133,10 @@ Apply the Settings
 ------------------
 
 Once the profiles have been created and tested, one way of applying the
-profile to all workstations is to use the SIMP ``hostgroup`` :term:`Hiera`
+profile to all workstations is to use the SIMP ``hostgroups`` :term:`Hiera`
 configuration capability.
 
-To do use ``hostgroups``, you will need to edit the ``site.pp`` in the target
+To use ``hostgroups``, you will need to edit the ``site.pp`` in the target
 :term:`puppet environment` :term:`site manifest`.
 
 Adding the following to

--- a/docs/user_guide/HOWTO/NFS.rst
+++ b/docs/user_guide/HOWTO/NFS.rst
@@ -100,7 +100,7 @@ Server
 ^^^^^^
 
 Create a manifest in your :term:`site profile`. In this example the
-site profile is named ``site`` and the manifest ``nfs_server.pp``
+site profile module is ``site`` and the manifest ``nfs_server.pp``
 
 ``site/manifests/nfs_server.pp``:
 
@@ -151,8 +151,8 @@ In ``hosts/<your_server_fqdn>.yaml``:
 Client
 ^^^^^^
 
-Create a manifest in your :term:`site profile`. In this example the
-site profile is named ``site`` and the manifest ``nfs_client.pp``
+Create a manifest in your :term:`site profile`.
+In this example the site profile module  is ``site`` and the manifest ``nfs_client.pp``
 
 .. code-block:: puppet
 
@@ -276,7 +276,7 @@ Server
 ^^^^^^
 
 Create a manifest in your :term:`site profile`. In this example the
-site profile is named ``site`` and the manifest ``nfs_server.pp``
+site profile module is ``site`` and the manifest ``nfs_server.pp``
 
 ``site/manifest/nfs_server.pp``;
 
@@ -358,7 +358,7 @@ Client
 ^^^^^^
 
 Create a manifest in your :term:`site profile`. In this example the
-site profile is named ``site`` and the manifest ``nfs_client.pp``
+site profile module is ``site`` and the manifest ``nfs_client.pp``
 
 ``site/manifests/nfs_client.pp``
 

--- a/docs/user_guide/HOWTO/NFS.rst
+++ b/docs/user_guide/HOWTO/NFS.rst
@@ -266,8 +266,9 @@ following the instructions in the previous section.
 Server
 ^^^^^^
 
-Create a manifest in the site module. In this example
-the manifest is called nfs_server.pp.
+The server side of the NFS shares should be contained in its own namespace. In
+this example the manifest is in a module called ``site`` and a file named
+``nfs_server.pp``.
 
 .. code-block:: puppet
 

--- a/docs/user_guide/HOWTO/NFS.rst
+++ b/docs/user_guide/HOWTO/NFS.rst
@@ -7,6 +7,12 @@ HOWTO Configure NFS
 All implementations are based on ``pupmod-simp-nfs``, ``pupmod-simp-simp_nfs``,
 and ``pupmod-simp-simp``.
 
+For ease of explanation, examples in this section use the concept of a :term:`site
+profile` and are namespaced accordingly.  The manifests are  in a
+module called ``site``.  If using a different site profile, change the directory and
+the namespace in the examples.
+
+
 .. NOTE::
 
    ``pupmod-simp-simp_nfs`` and ``pupmod-simp-nfs`` are not core modules, and
@@ -93,7 +99,10 @@ client.
 Server
 ^^^^^^
 
-In ``site/manifests/nfs_server.pp``:
+Create a manifest in your :term:`site profile`. In this example the
+site profile is named ``site`` and the manifest ``nfs_server.pp``
+
+``site/manifests/nfs_server.pp``:
 
 .. code-block:: puppet
 
@@ -142,8 +151,8 @@ In ``hosts/<your_server_fqdn>.yaml``:
 Client
 ^^^^^^
 
-
-In ``site/manifests/nfs_client.pp``:
+Create a manifest in your :term:`site profile`. In this example the
+site profile is named ``site`` and the manifest ``nfs_client.pp``
 
 .. code-block:: puppet
 
@@ -266,10 +275,10 @@ following the instructions in the previous section.
 Server
 ^^^^^^
 
-For ease of explanation, this example uses the concept of a :term:`site
-profile` and is namespaced accordingly. The server side of the NFS shares
-should be contained in its own namespace. In this example the manifest is in a
-module called ``site`` and a file named ``nfs_server.pp``.
+Create a manifest in your :term:`site profile`. In this example the
+site profile is named ``site`` and the manifest ``nfs_server.pp``
+
+``site/manifest/nfs_server.pp``;
 
 .. code-block:: puppet
 
@@ -348,9 +357,10 @@ Include this manifest in the servers hiera file.
 Client
 ^^^^^^
 
-To mount this directory to the client create a manifest in the site
-module that will create the mount point and mount the share. In this
-example it is called nfs_client.pp.
+Create a manifest in your :term:`site profile`. In this example the
+site profile is named ``site`` and the manifest ``nfs_client.pp``
+
+``site/manifests/nfs_client.pp``
 
 .. code-block:: puppet
 

--- a/docs/user_guide/HOWTO/NFS.rst
+++ b/docs/user_guide/HOWTO/NFS.rst
@@ -266,9 +266,10 @@ following the instructions in the previous section.
 Server
 ^^^^^^
 
-The server side of the NFS shares should be contained in its own namespace. In
-this example the manifest is in a module called ``site`` and a file named
-``nfs_server.pp``.
+For ease of explanation, this example uses the concept of a :term:`site
+profile` and is namespaced accordingly. The server side of the NFS shares
+should be contained in its own namespace. In this example the manifest is in a
+module called ``site`` and a file named ``nfs_server.pp``.
 
 .. code-block:: puppet
 

--- a/docs/user_guide/HOWTO/Redundant_LDAP.rst
+++ b/docs/user_guide/HOWTO/Redundant_LDAP.rst
@@ -147,9 +147,9 @@ If settings other than the defaults are needed, create a manifest under
 ``site`` and use the ``simp_openldap::server::syncrepl`` class with the necessary
 parameters.
 
-In this example, the site profile is called ``site::ldap_slave`` and the RID of
-the server is ``999`` (these can be changed). One setting, ``sizelimit``, is
-being overwritten but you can overwrite any number of them.
+In this example, the :term:`site profile` is called ``site::ldap_slave`` and
+the RID of the server is ``999`` (these can be changed). One setting,
+``sizelimit``, is being overwritten but you can overwrite any number of them.
 
 .. code-block:: puppet
 

--- a/docs/user_guide/PXE_Boot.inc
+++ b/docs/user_guide/PXE_Boot.inc
@@ -175,11 +175,10 @@ Installation Guides.
 
 Dynamic Linux Model Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Create a site manifest for the TFTP server on the Puppet master to set up the
-various files to model different systems.
+Create a :term:`site profile` module for the TFTP server on the Puppet master
+to set up the various files to model different systems.
 
-#. Create the file
-   ``/etc/puppetlabs/code/environments/simp/modules/site/manifests/tftpboot.pp``.
+#. Create the file ``tftpboot.pp`` in your :term:`site profile`.
    This file will contain Linux models for different types of systems and
    a mapping of MAC addresses to each model.
 
@@ -286,7 +285,7 @@ various files to model different systems.
         }
 
 
-#. Add the ``tftpboot`` site manifest on your puppet server node via
+#. Add the ``site::tftpboot`` class on your puppet server node via
    :term:`Hiera`.  Create the file (or edit if it exists):
    ``/etc/puppetlabs/code/environments/simp/data/hosts/<tftp.server.fqdn>.yaml``.
    (By default the TFTP server is the same as your puppet server so it should

--- a/docs/user_guide/SIMP_Administration/General_Administration/Nightly_Updates.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/Nightly_Updates.inc
@@ -90,7 +90,7 @@ Configuring the Clients
 Now that you have added this repository, you are going to want to add it to your
 clients.
 
-The best way to do this is to make it part of your site profile. You **can**
+The best way to do this is to make it part of your :term:`site profile`. You **can**
 make it part of your module, but you will need to wrap it in a Defined Type so
 that the server parameter can be modified.
 


### PR DESCRIPTION
- Removed all calls to the 'site' module specifically
- Rebranded references to the 'site' module as a convienient place holder and
  added appropriate glossary terms.
- Added glossary terms for:
  - Puppet Module
  - Puppet Namespace
  - Site Profile

SIMP-6363 #close