### PR TITLE
(SIMP-6579) Various cleanup items

### DIFF
--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -373,7 +373,7 @@ pupmod-simp-ssh
   ``ssh::server::conf::subsystem`` was erroneously stripped of whitespace.
 
 
-Modules Replacements 
+Modules Replacements
 --------------------
 
 The following modules are current and actively maintained replacements for
@@ -455,7 +455,7 @@ pupmod-simp-freeradius
 pupmod-simp-hirs_provisioner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* New module to install the :term:`HIRS` Provisioner and check-in with 
+* New module to install the :term:`HIRS` Provisioner and check-in with
   the Attestation Certificate Authority.
 
 pupmod-simp-iptables

--- a/docs/help/FAQ/10_Password_Complexity.rst
+++ b/docs/help/FAQ/10_Password_Complexity.rst
@@ -31,7 +31,7 @@ Complexity Rules
     * BAD: ``aaa``
 
   * No more than 3 repetitions of a character from the same character class
-  
+
     * OK: ``abcD``
     * BAD: ``abcd``
 

--- a/docs/help/FAQ/40_Audit_Syslog.rst
+++ b/docs/help/FAQ/40_Audit_Syslog.rst
@@ -7,7 +7,7 @@ Audit logs can be sent to syslog in addition to being persisted
 locally in ``/var/log/audit``.  However, SIMP disables forwarding
 of audit logs to syslog, by default, because the logs are voluminous,
 so when sent to one or more remote syslog servers, will usually
-overwhelm the underlying network.  
+overwhelm the underlying network.
 
 If forwarding of audit logs via syslog is appropriate for your site,
 you can enable that forwarding by setting the following in :term:`hiera`:

--- a/docs/user_guide/HOWTO.rst
+++ b/docs/user_guide/HOWTO.rst
@@ -16,7 +16,7 @@ with more commonly sought items towards the top.
   Set up a SIMP Control Repository <HOWTO/Control_Repo>
   Customize settings for SSH <HOWTO/Configure_Ssh>
   Set up SSH Authorized Keys <HOWTO/SSH_Keys>
-  Disable SSH <HOWTO/Disable_Ssh>
+  Disable SSH Management <HOWTO/Disable_Ssh>
   Restrict SSH Network Access <HOWTO/SSH_Restrict_Network_Access.rst>
   Enable SFTP Restricted Accounts <HOWTO/SFTP_Restricted_Accounts>
   Modify the Nightly Package Update Schedule <HOWTO/Control_Nightly_Update_Schedule>

--- a/docs/user_guide/HOWTO/Disable_Ssh.rst
+++ b/docs/user_guide/HOWTO/Disable_Ssh.rst
@@ -1,9 +1,9 @@
-HOWTO Disable SSH
-=================
+HOWTO Disable SSH Management
+============================
 
-If SSH is included in your SIMP scenario and you wish to cherry-pick
-it out of the class list and cease to manage its configuration, add
-the following Hiera:
+If ``simp-ssh`` is included in your SIMP scenario and you wish to cherry-pick
+it out of the class list and cease to manage its configuration, add the
+following to your :term:`Hiera` configuration:
 
 .. code-block::  yaml
 
@@ -11,9 +11,10 @@ the following Hiera:
    simp::classes:
      - '--ssh'
 
-SVCKill will *not* automatically kill sshd when you cease management
-of the module; it is whitelisted in the default ``svckill::ignore_default``
-list. If you want svckill to kill running sshd processes, include:
+``simp-svckill`` will *not* automatically kill ``sshd`` when you cease
+management of the module since it has been whitelisted by
+``svckill::ignore_default``. If you want ``svckill`` to kill running ``sshd``
+services then add the following to your Hiera configuration.
 
 .. code-block::  yaml
 

--- a/docs/user_guide/HOWTO/IPA_Clients.rst
+++ b/docs/user_guide/HOWTO/IPA_Clients.rst
@@ -44,7 +44,7 @@ Add Hosts to IPA
 There are two ways to complete this step:
 
 #. Use the IPA web interface, and take note of the one time password
-#. Run ``ipa host-add`` on the command line and pregenerate the password
+#. Run ``ipa host-add`` on the command line and pre-generate the password
 
 Only option 2 will be covered here.
 
@@ -76,7 +76,7 @@ To be able to add hosts from the command line:
 
       # In <domain>.yaml or whichever level is most specific
       ---
-      classes:
+      simp::classes:
       - simp_ipa::client::install
 
       simp_ipa::client::install::ensure: present
@@ -110,14 +110,16 @@ To be able to add hosts from the command line:
       resolv::resolv_domain: <IPA Domain>
 
 
-#. Next time Puppet runs via cron job, your node will be part of the IPA domain
-   and logins should work.
+#. Next time Puppet runs, your node will be part of the IPA domain and logins
+   should work.
 
 .. NOTE::
+
    Only users that are in an IPA group of type ``POSIX`` will be able to
    log into Linux systems.
 
 .. NOTE::
+
    The default UID and GID ranges are very high in IPA (in the low billions), so
    they are a lot higher than both the SIMP and SSSD default max. Set
    ``simp_options::uid::max`` appropriately to avoid this issue. Alternatively,
@@ -125,6 +127,7 @@ To be able to add hosts from the command line:
    ``--idstart=5000`` or by changing the UID ranges in the GUI.
 
 .. NOTE::
+
    Users and groups still have to be added to PAM to be able to log in!
 
 

--- a/docs/user_guide/HOWTO/Manage_TPM.rst
+++ b/docs/user_guide/HOWTO/Manage_TPM.rst
@@ -184,7 +184,7 @@ To initalize the TPM 2.0 simulator, issue the following commands:
 
 The ``tpm2_getcap`` command, provided by tpm2-tools RPM, can be used to verify
 the TPM 2.0 simulator has been initialized:
- 
+
    .. code-block:: bash
 
      # tpm2_getcap --capability="properties-fixed"
@@ -484,7 +484,7 @@ HIRS
 The SIMP hirs_provisioner module installs and configures the :term:`HIRS` TPM
 Provisoner on specified systems. An Attestation Certificate Authority (ACA)
 must be set up independently. Details of how to do this are provided on the
-:term:`HIRS` website. Additionally, the `acceptance tests`_ in the `SIMP 
+:term:`HIRS` website. Additionally, the `acceptance tests`_ in the `SIMP
 hirs_provisioner module`_ include an example of how to do so.
 
 To install and configure the HIRS TPM Provisioner, add the following Hiera:
@@ -499,8 +499,8 @@ To install and configure the HIRS TPM Provisioner, add the following Hiera:
 
 .. _IBM's Software TPM 1.2: https://sourceforge.net/projects/ibmswtpm/
 .. _IBM's Software TPM 2.0: https://sourceforge.net/projects/ibmswtpm2/
-.. _SIMP TPM 1.2 Simulator: https://github.com/simp/simp-tpm12-simulator 
-.. _SIMP TPM 2.0 Simulator: https://github.com/simp/simp-tpm2-simulator 
+.. _SIMP TPM 1.2 Simulator: https://github.com/simp/simp-tpm12-simulator
+.. _SIMP TPM 2.0 Simulator: https://github.com/simp/simp-tpm2-simulator
 .. _Intel Site: https://software.intel.com/en-us/articles/intel-trusted-execution-technology
 .. _acceptance tests: https://github.com/simp/pupmod-simp-hirs_provisioner/tree/master/spec/acceptance
-.. _SIMP hirs_provisioner module: https://github.com/simp/pupmod-simp-hirs_provisioner 
+.. _SIMP hirs_provisioner module: https://github.com/simp/pupmod-simp-hirs_provisioner

--- a/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
+++ b/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
@@ -4,16 +4,16 @@ HOWTO Manage Workstation Infrastructures
 ========================================
 
 This chapter describes example code used to manage client workstations with a
-SIMP system including GUIs, repositories, virtualization,
-printing, and Virtual Network Computing (VNC).
+SIMP system including the :term:`GUI`, repositories, virtualization, printing,
+and :term:`Virtual Network Computing` (VNC).
 
 Install Extra Puppet Modules
 ----------------------------
 
 The examples on this page use modules that are part of SIMP Extras and may not
-be installed on the puppet server by default.  The following is an example manifest
-that can be applied to the puppet server to install the extra modules if RPMs are being
-used to distribute the modules:
+be installed on the puppet server by default.  The following is an example
+manifest that can be applied to the puppet server to install the extra modules
+if RPMs are being used to distribute the modules:
 
 
 .. code-block:: ruby
@@ -170,7 +170,7 @@ See :ref:`Exporting_Home_Directories` for more information.
    simp_nfs::home_dir_server: myhome.server.com
 
    #The site::workstation manifest will do most of the work.
-   classes:
+   simp::classes:
      - site::workstation
      - simp_nfs
 
@@ -325,7 +325,7 @@ following in the target node's :term:`Hiera` data:
   x2go::server::agent_options:
     '-clipboard': 'both'
 
-  classes:
+  simp::classes:
     - 'x2go'
     - 'mate'
 
@@ -349,7 +349,7 @@ To install the client on a system, add the following in the client node's
   x2go::client: true
   x2go::server: false
 
-  classes:
+  simp::classes:
     - 'x2go'
 
 The x2go client on the client node can then be used to access the server node
@@ -440,7 +440,7 @@ VNC Server node
 .. code-block:: yaml
 
    # vserv.your.domain.yaml
-   classes:
+   simp::classes:
      - 'gnome'
      - 'mozilla::firefox'
      - 'vnc::server'
@@ -451,7 +451,7 @@ VNC client node
 .. code-block:: yaml
 
    # vclnt.your.domain.yaml
-   classes:
+   simp::classes:
      - 'gnome'
      - 'mozilla::firefox'
      - 'vnc::client'

--- a/docs/user_guide/PXE_Boot.inc
+++ b/docs/user_guide/PXE_Boot.inc
@@ -11,7 +11,7 @@ SIMP client. Follow your own sites procedures for this.
 
 In this section we describe how to configure the Kickstart and :term:`TFTP`
 servers to PXE boot a SIMP client.  (The DNS and DHCP server setup, also
-  required for PXE booting, are discussed in an earlier chapter.)
+required for PXE booting, are discussed in an earlier chapter.)
 
 .. NOTE::
 

--- a/docs/user_guide/PXE_Boot.inc
+++ b/docs/user_guide/PXE_Boot.inc
@@ -1,6 +1,5 @@
 .. _Configure_PXE_Boot:
 
-
 Configure PXE Boot
 ==================
 
@@ -10,9 +9,9 @@ located in the DVD under ``/images/pxeboot``.  If you have an existing
 :term:`Preboot Execution Environment` (PXE) setup you can use these to PXE a
 SIMP client. Follow your own sites procedures for this.
 
-In this section we describe how to configure the Kickstart and TFTP servers to
-PXE boot a SIMP client.  (The DNS and DHCP server setup, also required for PXE
-booting, are discussed in an earlier chapter.)
+In this section we describe how to configure the Kickstart and :term:`TFTP`
+servers to PXE boot a SIMP client.  (The DNS and DHCP server setup, also
+  required for PXE booting, are discussed in an earlier chapter.)
 
 .. NOTE::
 
@@ -40,7 +39,7 @@ This section describes how to configure the kickstart server.
      .. code-block:: yaml
 
         ---
-        classes:
+        simp::classes:
           - simp::server::kickstart
 
    - This profile class adds management of DHCP, DNS, the Kickstart service,
@@ -294,7 +293,7 @@ to set up the various files to model different systems.
    .. code-block:: yaml
 
       ---
-      classes:
+      simp::classes:
         - 'site::tftpboot'
 
 

--- a/docs/user_guide/SIMP_Administration/Classification_and_Data/Assigning_Classes_to_Nodes.inc
+++ b/docs/user_guide/SIMP_Administration/Classification_and_Data/Assigning_Classes_to_Nodes.inc
@@ -1,25 +1,33 @@
 Assigning Classes to Nodes
 --------------------------
 
-Assigning classes to nodes can be done in a few ways in SIMP. First, there is a
-``lookup`` function in ``/etc/puppetlabs/code/environments/simp/manifests/site.pp``
-that looks for an array called ``classes`` in your hierarchy. It also looks for
-an array called ``class_exclusions``, which can be used to remove classes from
-the classes array. The classes that are included are the result of
-``$classes - $class_exclusions``. If classes need to be added to all nodes, a
-``classes`` array could be added to the ``default.yaml`` in your hiera data,
-like this:
+To preserve various levels of ordering and overrides, it is highly recommended
+that you use the ``simp::classes`` class paramter in :term:`Hiera` to manage
+standard class inclusions.
+
+This allows you to correctly use the ``--`` knockout prefix to exclude classes
+at any level of your hierarchy.
 
 .. code-block:: yaml
+   :caption: Example Class Management
 
    ---
-   classes:
-     - 'site::example_class'
+   simp::classes:
+     # Add the 'gnome' class to the standard list
+     - gnome
+     # Remove the 'ntp' class because we want to use our own
+     - --ntp
 
+Legacy Method
+^^^^^^^^^^^^^
 
-A similar array could be created in any other layer in the hierarchy, and it
-will be merged with the 'unique' strategy by the ``lookup`` function noted
-above.
+SIMP also includes class inclusion functionality via a top-level ``classes``
+array in your Hiera hierarchy. Though this is no longer recommended, it is
+still supported.
+
+In this case, instead of using the knockout prefix, there is also a
+``class_exclusions`` array that will be used to remove classes from the
+include list.
 
 The SIMP profile module also includes other classes needed for a secure
 baseline, which are discussed below in the :ref:`SIMP scenarios <simp scenarios>`

--- a/docs/user_guide/SIMP_Administration/Classification_and_Data/Assigning_Classes_to_Nodes.inc
+++ b/docs/user_guide/SIMP_Administration/Classification_and_Data/Assigning_Classes_to_Nodes.inc
@@ -2,7 +2,7 @@ Assigning Classes to Nodes
 --------------------------
 
 To preserve various levels of ordering and overrides, it is highly recommended
-that you use the ``simp::classes`` class paramter in :term:`Hiera` to manage
+that you use the ``simp::classes`` class parameter in :term:`Hiera` to manage
 standard class inclusions.
 
 This allows you to correctly use the ``--`` knockout prefix to exclude classes

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.3.3_6.4.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.3.3_6.4.0.inc
@@ -139,7 +139,7 @@ Edit the main Puppetfile:
 
 * Make sure all the local modules you created and have in the modules
   directory have ``:local => true`` entries. This includes the ``site``
-  module, which is no longer delivered as an RPM.  
+  module, which is no longer delivered as an RPM.
 * Delete the ``local => true`` entries for any obsolete modules that you
   do not need (e.g. ``simpcat``).
 

--- a/docs/user_guide/User_Management/Local_Users.rst
+++ b/docs/user_guide/User_Management/Local_Users.rst
@@ -22,7 +22,7 @@ In ``default.yaml``:
 
 .. code-block:: yaml
 
-  classes:
+  simp::classes:
     - 'site::local_account'
     - 'site::service_account'
 

--- a/docs/user_guide/User_Management/SSSD.rst
+++ b/docs/user_guide/User_Management/SSSD.rst
@@ -18,46 +18,47 @@ wish but are presented as classes for simplicity.
 SSSD LOCAL Domain
 -----------------
 
-Set up a LOCAL domain in SSSD. If one already exists in /etc/sssd/sssd.conf,
-you can optionally skip this step.  If the LOCAL domain is not managed with
-SIMP, you may experience difficulties.
+Set up a LOCAL domain in SSSD. If one already exists in
+``/etc/sssd/sssd.conf``, you can optionally skip this step.  If the LOCAL
+domain is not managed with SIMP, you may experience difficulties.
 
 .. code-block:: ruby
 
-  class site::sssd_local {
+   class site::sssd_local {
 
-    sssd::provider::local { 'LOCAL': }
+     sssd::provider::local { 'LOCAL': }
 
-    sssd::domain { 'LOCAL':
-      description   => 'Default Local Domain',
-      id_provider   => 'local',
-      auth_provider => 'local'
-    }
-  }
+     sssd::domain { 'LOCAL':
+       description   => 'Default Local Domain',
+       id_provider   => 'local',
+       auth_provider => 'local'
+     }
+   }
 
 In ``default.yaml``:
 
 .. code-block:: yaml
 
-  classes:
-    - 'site::sssd_local'
+   simp::classes:
+     - 'site::sssd_local'
 
-In :term:`Hiera`, you will need to add the LOCAL sssd domain to
+In :term:`Hiera`, you will need to add the ``LOCAL`` ``sssd`` domain to
 ``sssd::domains`` if it does not already exist.  If you wish to include the
-LOCAL domain in all of ``$simp_options::trusted_nets``, simply add ``sssd::domains`` variable
-to ``default.yaml``, copy existing domains from ``simp_config_settings.yaml``
-and add ``local`` to the list of domain ``id_providers``.
+LOCAL domain in all of ``$simp_options::trusted_nets``, simply add
+``sssd::domains`` variable to ``default.yaml``, copy existing domains from
+``simp_config_settings.yaml`` and add ``local`` to the list of domain
+``id_providers``.
 
 In ``default.yaml``:
 
 .. code-block:: yaml
 
-  sssd::domains:
-    - 'LOCAL'
-    - <existing domains, ex. LDAP>
+   sssd::domains:
+     - 'LOCAL'
+     - <existing domains, ex. LDAP>
 
 Run ``puppet``. A LOCAL domain should be created and referenced in
-``/etc/sssd/sssd.conf``.  The sssd service should be running.
+``/etc/sssd/sssd.conf``.  The ``sssd`` service should be running.
 
 Adding an SSSD Local User
 -------------------------
@@ -67,51 +68,52 @@ for more options.
 
 .. code-block:: shell
 
-  sss_useradd <user> -h </path/to/home/dir> -u <uid> -m -k /etc/skel
+   sss_useradd <user> -h </path/to/home/dir> -u <uid> -m -k /etc/skel
 
 
 .. NOTE:
-  There is a bug in :term:`EL` 6 which does not allow sssd to modify
-  ``/etc/passwd``.
+
+   There is a bug in :term:`EL` 6 which does not allow sssd to modify
+   ``/etc/passwd``.
 
 To update an EL6 system, perform the following step
 
 .. code-block:: shell
 
-  vipw
-  <user>:x:<uid>:<gid>::</path/to/home/dir>:/bin/bash
+   vipw
+   <user>:x:<uid>:<gid>::</path/to/home/dir>:/bin/bash
 
-Next, set the user's password.  As root, run:
+Next, set the user's password.  As ``root``, run:
 
 .. code-block:: shell
 
-  passwd <user>
+   passwd <user>
 
 Giving the User Access
 ----------------------
 
 .. code-block:: ruby
 
-  pam::access::rule { '<user> access':
-    permission => '+',
-    users      => ['<user>'],
-    origins    => ['ALL'],
-    order      => 1000
-  }
+   pam::access::rule { '<user> access':
+     permission => '+',
+     users      => ['<user>'],
+     origins    => ['ALL'],
+     order      => 1000
+   }
 
-  sudo::user_specification { '<user> privs':
-    user_list => ["<user>"],
-    host_list => [$::fqdn],
-    runas     => 'root',
-    cmnd      => ['/bin/cat /var/log/app.log'],
-    passwd    => false
-  }
+   sudo::user_specification { '<user> privs':
+     user_list => ["<user>"],
+     host_list => [$::fqdn],
+     runas     => 'root',
+     cmnd      => ['/bin/cat /var/log/app.log'],
+     passwd    => false
+   }
 
 You are done! You should be able to ``id <user>``, ``su - <user>``, and run
-commands allowed by sudo rules.
+commands allowed by ``sudo`` rules.
 
-Test authentication by ssh-ing as the ``user`` onto the host machine, with the
-password specified after user creation.  If you want to set up a ssh key,
-you may want to follow the relevant `GitHub documentation`_.
+Test authentication by connecting via ``ssh`` as ``user`` onto the host
+machine, with the password specified after user creation.  If you want to set
+up a ``ssh`` key, you may want to follow the relevant `GitHub documentation`_.
 
 .. _GitHub documentation: https://help.github.com/en/articles/connecting-to-github-with-ssh


### PR DESCRIPTION
* Removed trailing whitespace
* Minor documentation updates
* Clarified assigning classes to use simp::classes
* Modified 'classes:' to be 'simp::classes:' except where other PRs are
  addressing the change

SIMP-6579 #comment various cleanup items