### PR TITLE
(SIMP-7017) Fix docs:pdf errors on PNG images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ python:
   - 2.7
 script: true
 
-stages:
-  - name: Python unit tests
-  - name: Sphinx HTML build
-  - name: Sphinx PDF build
-    if: 'env(BUILD_PDF) = yes'
-  - name: Sphinx link check
-
 jobs:
   include:
     - stage: Python unit tests
@@ -24,11 +17,14 @@ jobs:
     # on the master branch. It always returns a 403 error, even if it's given a token.
     - script: pytest -x --capture=no docs/conflib/release_mapping_test.py || true
 
-    - stage: Sphinx HTML build
+    - stage: Sphinx docs build
+      name: Sphinx HTML build
       script: sphinx-build -n -b html -d sphinx_cache docs html
 
-    - stage: Sphinx PDF build
+    - stage: Sphinx docs build
+      name: Sphinx PDF build
       script: sphinx-build -E -n -b pdf -d sphinx_cache docs pdf
+      if: 'env(BUILD_PDF) = yes'
 
     - stage: Sphinx link check
       script: sphinx-build -E -n -b linkcheck docs linkcheck || ( cat linkcheck/output.txt ; false )

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ python:
   - 2.7
 script: true
 
+stages:
+  - name: Python unit tests
+  - name: Sphinx HTML build
+  - name: Sphinx PDF build
+    if: 'env(BUILD_PDF) = yes'
+  - name: Sphinx link check
+
 jobs:
   include:
     - stage: Python unit tests
@@ -19,6 +26,9 @@ jobs:
 
     - stage: Sphinx HTML build
       script: sphinx-build -n -b html -d sphinx_cache docs html
+
+    - stage: Sphinx PDF build
+      script: sphinx-build -E -n -b pdf -d sphinx_cache docs pdf
 
     - stage: Sphinx link check
       script: sphinx-build -E -n -b linkcheck docs linkcheck || ( cat linkcheck/output.txt ; false )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Babel>=2.3
 Jinja2>=2.8
 MarkupSafe>=0.23
-Pillow>=2.9.0
+Pillow>=2.9.0,<=5.4.0
 PyYAML>=5.1
 Pygments>=2.0.2
 Sphinx>=1.4.4,<1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Babel>=2.3
 Jinja2>=2.8
 MarkupSafe>=0.23
-Pillow>=2.9.0,<=5.4.0
+Pillow>=2.9.0,<6
 PyYAML>=5.1
 Pygments>=2.0.2
 Sphinx>=1.4.4,<1.8.0


### PR DESCRIPTION
This patch fixes an issue that where `sphinx-build -b pdf` would fail
while processing inline PNG images.  This problem would cause both `rake
docs:pdf` and simp-doc RPM builds to fail.

It also adds an optional "Sphinx PDF build" step to the Travis CI
pipeline, which can be enabled by setting `env: BUILD_PDF=yes`.

SIMP-7017 #close