### PR TITLE
(SIMP-6936) HOWTO for simp config env change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Aug 19 2020 Trevor Vaughan <tvaughan@onyxpoint.com>
+- Added HOWTO on changing the inital 'simp config' puppet environment
+
 * Tue May 26 2020 Trevor Vaughan <tvaughan@onyxpoint.com>
 - Added HOWTO on enabling system core dumps.
 

--- a/docs/user_guide/HOWTO.rst
+++ b/docs/user_guide/HOWTO.rst
@@ -40,6 +40,7 @@ with more commonly sought items towards the top.
   Enroll hosts in an IPA domain <HOWTO/IPA_Clients>
   Manage TPM <HOWTO/Manage_TPM>
   Set up and Utilize Bolt <HOWTO/Bolt>
-  Block or Cache Facts<HOWTO/Block_or_Cache_Facts>
+  Block or Cache Facts <HOWTO/Block_or_Cache_Facts>
   Upgrade SIMP <HOWTO/Upgrade_SIMP>
+  Use an Alternate ``simp config`` Environment <HOWTO/Alternate_SIMP_Config_Environment>
   Use the SIMP Release RPM<HOWTO/Using_the_SIMP_Release_RPM>

--- a/docs/user_guide/HOWTO/Alternate_SIMP_Config_Environment.rst
+++ b/docs/user_guide/HOWTO/Alternate_SIMP_Config_Environment.rst
@@ -1,6 +1,6 @@
 .. _howto-use-an-alternate-simp-config-environment:
 
-HOWTO Use an Alternate ``simp config`` Environment
+HOWTO Use an Alternate 'simp config' Environment
 ==================================================
 
 Generally, when running the ``simp config`` and ``simp bootstrap`` commands, all

--- a/docs/user_guide/HOWTO/Alternate_SIMP_Config_Environment.rst
+++ b/docs/user_guide/HOWTO/Alternate_SIMP_Config_Environment.rst
@@ -10,9 +10,10 @@ items will be placed into the ``production`` :term:`Puppet Environment` and
 If you are installing SIMP onto a preexisting system, you may want to instead
 install into an environment other than ``production``.
 
-As of version 6.0.0, the ``simp-cli`` was updated to support setting an
-alternate initial environment using a shell environment variable called
-``SIMP_ENVIRONMENT``.
+As of ``simp-cli`` version 6.0.0 (new with SIMP 6.5), you can configure
+the ``simp config`` and ``simp bootstrap`` commands to use an
+alternate initial environment by setting the shell environment 
+variable, ``$SIMP_ENVIRONMENT``.
 
 For example, if you wanted to name your initial environment ``simp``, then you
 would do the following:

--- a/docs/user_guide/HOWTO/Alternate_SIMP_Config_Environment.rst
+++ b/docs/user_guide/HOWTO/Alternate_SIMP_Config_Environment.rst
@@ -1,0 +1,27 @@
+.. _howto-use-an-alternate-simp-config-environment:
+
+HOWTO Use an Alternate ``simp config`` Environment
+==================================================
+
+Generally, when running the ``simp config`` and ``simp bootstrap`` commands, all
+items will be placed into the ``production`` :term:`Puppet Environment` and
+:term:`SIMP Secondary Environment`.
+
+If you are installing SIMP onto a preexisting system, you may want to instead
+install into an environment other than ``production``.
+
+As of version 6.0.0, the ``simp-cli`` was updated to support setting an
+alternate initial environment using a shell environment variable called
+``SIMP_ENVIRONMENT``.
+
+For example, if you wanted to name your initial environment ``simp``, then you
+would do the following:
+
+  .. code-block:: bash
+
+     export SIMP_ENVIRONMENT='simp'
+     simp config
+     ...
+     simp bootstrap
+
+See :ref:`gsg-advanced-configuration` for more information on ``simp config``.

--- a/docs/user_guide/Initial_Server_Configuration.rst
+++ b/docs/user_guide/Initial_Server_Configuration.rst
@@ -24,6 +24,10 @@ For a list of the commands ``simp`` provides, type ``simp help``. Type
     changing anything and then run ``simp config  -a /root/.simp/simp_conf.yaml``
     to apply the changes.
 
+  * ``simp config`` uses the ``production`` :term:`Puppet Environment` by
+    default. If you want to use a different intial environment, see
+    :ref:`howto-use-an-alternate-simp-config-environment`.
+
 - ``simp bootstrap`` uses several targeted Puppet runs to configure the rest
   of the system and generates a log file under ``/root/.simp/``.
 


### PR DESCRIPTION
Added a HOWTO for using an alternate target environment during `simp
config` and `simp bootstrap`

SIMP-6936 #comment Added HOWTO for 'simp config' environment change