### PR TITLE
(SIMP-MAINT) Update asset release procedures

### DIFF
--- a/docs/contributors_guide/maintenance/ruby_gem_release_procedures/Release_GitHub_Deploy_RubyGems_org.rst
+++ b/docs/contributors_guide/maintenance/ruby_gem_release_procedures/Release_GitHub_Deploy_RubyGems_org.rst
@@ -25,13 +25,12 @@ To create the releases from an annotated tag:
       cd rubygem-simp-rake-helpers
       git checkout BRANCH # this step isn't needed for master branch
 
-#. Manually generate the changelog content in a file.
+#. Generate the changelog content
 
-   * The first line should be blank.
-   * The second line should be 'Release of x.y.z'
-   * The third line should be blank
-   * The remaining lines should contain the list of changes.
+   .. code-block:: bash
 
+      bundle update
+      bundle exec rake pkg:create_tag_changelog > foo
 
 #. Create the annotated tag.  In this example the content of ``foo`` is:
 


### PR DESCRIPTION
pkg:compare_create_tag_changelog has worked on asset repos for
quite some time! This update uses it to simplify the release
procedures.