### PR TITLE
(SIMP-MAINT) Revert changes from #376

### DIFF
--- a/docs/contributors_guide/maintenance/ruby_gem_release_procedures/Release_GitHub_Deploy_RubyGems_org.rst
+++ b/docs/contributors_guide/maintenance/ruby_gem_release_procedures/Release_GitHub_Deploy_RubyGems_org.rst
@@ -25,12 +25,13 @@ To create the releases from an annotated tag:
       cd rubygem-simp-rake-helpers
       git checkout BRANCH # this step isn't needed for master branch
 
-#. Generate the changelog content
+#. Manually generate the changelog content in a file.
 
-   .. code-block:: bash
+   * The first line should be blank.
+   * The second line should be 'Release of x.y.z'
+   * The third line should be blank
+   * The remaining lines should contain the list of changes.
 
-      bundle update
-      bundle exec rake pkg:create_tag_changelog > foo
 
 #. Create the annotated tag.  In this example the content of ``foo`` is:
 


### PR DESCRIPTION
This reverts commit 26dfdb49af7c0b8b3d72010958a312e319986e01.

The `pkg:create_tag_changelog` task is available for Puppet modules, but
not RubyGems.