### PR TITLE
(SIMP-8377) Updated NFS documentation

### DIFF
--- a/docs/user_guide/HOWTO/Manage_TPM.rst
+++ b/docs/user_guide/HOWTO/Manage_TPM.rst
@@ -444,7 +444,7 @@ Steps
       tpm::tboot::sinit_source: 'file:///root/txt/2nd_gen_i5_i7-SINIT_51/2nd_gen_i5_i7_SINIT_51.BIN'
       tpm::tboot::owner_password: "%{alias('tpm::ownership::owner_pass')}"
 
-#. Add the ``tpm::tboot`` class to the classes array with ``tpm``.
+#. Add the ``tpm::tboot`` class to the ``simp::classes`` array with ``tpm``.
 
    * The ``tpm::tboot`` class adds two boot entries to the GRUB configuration.
      One should read ``tboot``, and there should be one above it called

--- a/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
+++ b/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
@@ -278,8 +278,8 @@ The ``workstation.yaml`` file will include settings for all the workstations.
 
 The following example includes the GUI settings discussed here, in addition
 to settings for NFS mounted home directories.
-See :ref:`Exporting_Home_Directories` :ref:`ug-howto-configure-nfs` and for more
-information.
+See :ref:`Exporting_Home_Directories_For_LDAP_Users` :ref:`ug-howto-configure-nfs`
+and for more information.
 
 .. code-block:: yaml
 
@@ -289,9 +289,8 @@ information.
    simp::runlevel: 'graphical'
    timezone::timezone: 'EST'
 
-   # Settings for home server
-   nfs::is_server: false
-   simp_nfs::home_dir_server: myhome.server.com
+   # Settings to mount home server
+   simp_nfs::home_dir_server: <home server's IP address>
 
    # The site::workstation manifest will do most of the work.
    simp::classes:

--- a/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
+++ b/docs/user_guide/HOWTO/Managing_Workstation_Infrastructures.rst
@@ -93,7 +93,7 @@ install the extra software needed:
 
    class site::repos {
      yumrepo { 'myrepo':
-       #what ever parameters you need
+       # whatever parameters you need
      }
    }
 
@@ -119,8 +119,8 @@ The following example class, ``site::gui``, may be written to
 
      Class['Gnome'] -> Class['Site::gui']
 
-     #SIMP gnome package provides a basic interface.
-     #Add gnome extensions for the users.
+     # SIMP gnome package provides a basic interface.
+     # Add gnome extensions for the users.
      package { [
        'gnome-color-manager',
        'gnome-shell-extension-windowsNavigator',
@@ -129,7 +129,7 @@ The following example class, ``site::gui``, may be written to
         ensure => installed,
      }
 
-     #Gui applications
+     # GUI applications
      if $libreoffice {
        package { 'libreoffice': ensure => installed }
      }
@@ -278,21 +278,22 @@ The ``workstation.yaml`` file will include settings for all the workstations.
 
 The following example includes the GUI settings discussed here, in addition
 to settings for NFS mounted home directories.
-See :ref:`Exporting_Home_Directories` for more information.
+See :ref:`Exporting_Home_Directories` :ref:`ug-howto-configure-nfs` and for more
+information.
 
 .. code-block:: yaml
 
    ---
 
-   #Set the run level so it will bring up a graphical interface
+   # Set the run level so it will bring up a graphical interface
    simp::runlevel: 'graphical'
    timezone::timezone: 'EST'
 
-   #Settings for home server. See HOWTO NFS for more info.
+   # Settings for home server
    nfs::is_server: false
    simp_nfs::home_dir_server: myhome.server.com
 
-   #The site::workstation manifest will do most of the work.
+   # The site::workstation manifest will do most of the work.
    simp::classes:
      - site::workstation
      - simp_nfs

--- a/docs/user_guide/HOWTO/NFS.rst
+++ b/docs/user_guide/HOWTO/NFS.rst
@@ -3,7 +3,7 @@
 HOWTO Configure NFS
 ===================
 
-.. contents:: This chapter describes multiple configurations of NFS including:
+.. contents:: This chapter describes multiple configurations of NFS.  Topics include:
    :local:
 
 All implementations are based on the ``simp-nfs``, ``simp-simp_nfs``,
@@ -13,8 +13,10 @@ and ``simp-simp`` modules.
 
    ``simp-nfs`` version 7.0.0 and ``simp-autofs`` version 7.0.0 had major
    breaking changes in the pursuit of fixing long-standing bugs. General usage
-   as noted in this document remains the same but a lot of the nuanced usage
-   under the hood has changed. Please check your settings carefully on upgrade.
+   as noted in this document remains largely the same, but there are many
+   changes to the API, some of which are nuanced.  For example, parameters that
+   used to accept hostnames now require IP addresses in support of firewalld.
+   Please check your settings carefully on upgrade.
 
 For ease of explanation, examples in this section use the concept of a
 :term:`site profile` and are namespaced accordingly.  The manifests are in a
@@ -38,19 +40,17 @@ Known Issues
 Stunnel and Autofs
 ^^^^^^^^^^^^^^^^^^
 
-The ``autofs`` packages that were released with CentOS 6.8 (`autofs-5.0.5-122`_)
-and CentOS 7.3 (`autofs-5.0.7-56`_) worked properly over a :term:`stunnel`
-connection.
+The ``autofs`` package that was released with CentOS 7.3 (`autofs-5.0.7-56`_)
+worked properly over a :term:`stunnel` connection.
 
-The releases shipped with CentOS 6.9 (**5.0.5-132**)  and with CentOS 7.4 (**5.0.7-69**)
-prevent any connection from happening to the local ``stunnel`` process and
-break mounts to remote systems over ``stunnel`` connections.
+The release shipped with with CentOS 7.4 (**5.0.7-69**) prevents any connection
+from happening to the local ``stunnel`` process and breaks mounts to remote systems
+over ``stunnel`` connections.
 
-The releases that ship with CentOS 6.10 (**5.0.5-139**) and CentOS 7.6
-(**5.0.7-99**) have fixed the issue.
+The release that ship with CentOS 7.6 (**5.0.7-99**) has fixed the issue.
 
-To use :term:`NFS` over ``stunnel`` and ``automount`` directories the old
-package must be used or you must update to the latest release.
+To use :term:`NFS` over ``stunnel`` and ``automount`` directories with old
+CentOS 7 releases, you must use the appropriate ``autofs`` package.
 
 To determine what version of ``autofs`` is installed, run ``automount -V``.
 
@@ -59,69 +59,49 @@ To force the package to the desired version:
 * Make sure the package is available via your package-management facility then
   set the package version in :term:`Hiera`:
 
-In :term:`EL` 7+:
+.. code-block:: yaml
 
-.. code-block:: puppet
-
-   ---
    autofs::autofs_package_ensure: '5.0.7-99'
-
-In :term:`EL` 6
-
-.. code-block:: puppet
-
-   ---
-   autofs::autofs_package_ensure: '5.0.5-139'
 
 * Alternatively, ensure that the latest packages are available and set the
   following:
 
-.. code-block:: puppet
+.. code-block:: yaml
 
-   ---
    autofs::autofs_package_ensure: 'latest'
 
 
-The associated bug reports can be found at:
+The associated bug report can be found at:
 
-- CentOS 6  https://bugs.centos.org/view.php?id=13575.
 - CentOS 7  https://bugs.centos.org/view.php?id=14080.
 
-Autofs Option in ``nfs::client::mount``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Limited Kerberos Support
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``autofs`` option in ``nfs::client::mount`` resource currently only works
-with indirect wild-card mounts.  For all other ``autofs`` options use the
-``autofs`` module directly.
+SIMP's NFS modules provide limited support for Kerberos and will not be
+discussed here.
 
-See: `SIMP-2944`_.
+* See the `README`_ for ``simp-nfs`` for information about the Kerberos
+  support it provides and its integration with the ``simp-krb5`` module.
+* The ``simp-krb5`` module is not fully integrated with NFS home directories at
+  this time.  See `SIMP-1407`_ for details.
 
-Kerberos and Home Directories
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``simp-krb5`` module is not fully integrated with NFS home directories at
-this time.
-
-See `SIMP-1407`_ .
 
 Exporting Directories
 ---------------------
 
-**Goal:** Export ``/var/nfs_share`` on the server, mount as ``/mnt/nfs`` on the
-client.
+**Goal:**
 
-.. NOTE::
-
-   If anything in this section does not make sense, there is a full working
-   example of how to export NFS home directories in the ``simp_nfs`` module.
+  * Export */var/nfs_share* on the server, for read-only access.
+  * Mount as */mnt/nfs* on the client.
 
 Server
 ^^^^^^
 
-Create a manifest in your :term:`site profile`. In this example the
-site profile module is ``site`` and the manifest ``nfs_server.pp``
+Create a manifest in your :term:`site profile`. In this example the manifest
+in the ``site`` module is *nfs_server.pp*.
 
-``site/manifests/nfs_server.pp``:
+In *site/manifests/nfs_server.pp*:
 
 .. code-block:: puppet
 
@@ -136,7 +116,7 @@ site profile module is ``site`` and the manifest ``nfs_server.pp``
        ensure => 'directory',
        owner  => 'root',
        group  => 'root',
-       mode   => '0644'
+       mode   => '0755'
      }
 
      if !$nfs::stunnel {
@@ -148,19 +128,21 @@ site profile module is ``site`` and the manifest ``nfs_server.pp``
        }
      }
      else {
-       # Stunnel needs to point at the local host
        nfs::server::export { 'nfs_share':
-         clients     => ['127.0.0.1'],
+         # From the NFS server's perspective, the stunneled connections will
+         # come from the local host
+         clients     => [ '127.0.0.1' ],
          export_path => $data_dir,
+         insecure    => true,
          sec         => $sec,
          require     => File[$data_dir]
        }
      }
    }
 
-In ``hosts/<your_server_fqdn>.yaml``:
+In *data/hosts/<your NFS server FQDN>.yaml*:
 
-.. code-block:: puppet
+.. code-block:: yaml
 
    nfs::is_server: true
 
@@ -170,74 +152,145 @@ In ``hosts/<your_server_fqdn>.yaml``:
 Client
 ^^^^^^
 
-Create a manifest in your :term:`site profile`.
-In this example the site profile module  is ``site`` and the manifest ``nfs_client.pp``
+The client can be configured to mount statically, automatically with a direct
+autofs mount, or automatically with an indirect autofs mount. Examples for all
+three types will be shown in this section.  The indirect autofs mount example
+will configure autofs for an indirect mount that uses key substitution.
+
+
+.. NOTE::
+
+   If the NFS client is also a NFS server, there is autodetect logic in
+   ``nfs::client::mount`` that attempts to detect that the client has both
+   roles and, when this condition is detected, sets the NFS server's IP to
+   ``127.0.0.1`` for efficiency. This detection logic has limitations. So,
+   if you know the client is also the NFS server, it is better to disable
+   the auto-detection by setting ``nfs::client::mount::autodetect_remote``
+   to ``false``, and then set the ``nfs::client::mount::nfs_server`` to
+   ``127.0.0.1``.
+
+Static Mount
+""""""""""""
+
+Create a manifest in your :term:`site profile`.  In this example the manifest
+in the ``site`` modules is *nfs_client.pp*.
+
+In *site/manifests/nfs_client.pp*:
 
 .. code-block:: puppet
 
    class site::nfs_client (
-    Simplib::Host                                    $nfs_server,
-    Enum['none','sys','krb5','krb5i','krb5p']        $sec = 'sys'
+    Simplib::Ip                               $nfs_server,
+    Enum['none','sys','krb5','krb5i','krb5p'] $sec = 'sys'
   ){
 
      $_mnt_point = '/mnt/nfs'
 
-     file { "${_mnt_point}":
+     file { $_mnt_point:
        ensure => 'directory',
        mode   => '755',
        owner  => 'root',
        group  => 'root'
      }
 
-     nfs::client::mount { "${_mnt_point}":
+     nfs::client::mount { $_mnt_point:
        nfs_server  => $nfs_server,
        remote_path => '/var/nfs_share',
        sec         => $sec,
-       at_boot     => true,
        autofs      => false,
-       require     => File["${_mnt_point}"]
+       # The mount point must already exist in a static mount
+       require     => File[$_mnt_point]
      }
   }
 
-In ``hosts/<your_client_fqdn>.yaml``:
+In *data/hosts/<your NFS client FQDN>.yaml*:
 
 .. code-block:: yaml
 
-   nfs::is_server: false
-   site::nfs_client::nfs_server: <your nfs server>
+   site::nfs_client::nfs_server: <your NFS server IP>
 
    simp::classes:
      - 'site::nfs_client'
 
-.. WARNING::
+Direct autofs Mount
+"""""""""""""""""""
 
-   Non-wildcard indirect autofs mounts configured via ``nfs::client::mount``
-   are not working properly at this time. See `SIMP-2944`_ for additional
-   information.
+Create a manifest in your :term:`site profile`.  In this example the manifest
+in the ``site`` module is *nfs_client.pp*.
 
-   You may wish to manually configure the mount via
-   ``autofs::map::master``, and ``autofs::map::entry`` instead.
+In *site/manifests/nfs_client.pp*:
 
-.. NOTE::
+.. code-block:: puppet
 
-   The ``simp_nfs`` module contains a further example that includes the use of
-   a NFS root on the server and indirect autofs with wildcards on the client.
+   class site::nfs_client (
+    Simplib::Ip                               $nfs_server,
+    Enum['none','sys','krb5','krb5i','krb5p'] $sec = 'sys'
+  ){
 
-.. _Exporting_Home_Directories:
+     nfs::client::mount { '/mnt/nfs':
+       nfs_server  => $nfs_server,
+       remote_path => '/var/nfs_share',
+       sec         => $sec
+     }
+  }
 
-Exporting Home Directories
---------------------------
+In *data/hosts/<your NFS client FQDN>.yaml*:
+
+.. code-block:: yaml
+
+   site::nfs_client::nfs_server: <your NFS server IP>
+
+   simp::classes:
+     - 'site::nfs_client'
+
+Indirect autofs Mount with Key Substitution
+"""""""""""""""""""""""""""""""""""""""""""
+
+Create a manifest in your :term:`site profile`.  In this example the manifest
+in the ``site`` module is *nfs_client.pp*.
+
+In *site/manifests/nfs_client.pp*:
+
+.. code-block:: puppet
+
+   class site::nfs_client (
+    Simplib::Ip                               $nfs_server,
+    Enum['none','sys','krb5','krb5i','krb5p'] $sec = 'sys'
+  ){
+
+     nfs::client::mount { '/mnt/nfs':
+       nfs_server              => $nfs_server,
+       remote_path             => '/var/nfs_share',
+       sec                     => $sec,
+       autofs_indirect_map_key => '*',
+       autofs_add_key_subst    => true
+     }
+  }
+
+In *data/hosts/<your NFS client FQDN>.yaml*:
+
+.. code-block:: yaml
+
+   site::nfs_client::nfs_server: <your NFS server IP>
+
+   simp::classes:
+     - 'site::nfs_client'
+
+.. _Exporting_Home_Directories_For_LDAP_Users:
+
+Exporting Home Directories for LDAP Users
+-----------------------------------------
 
 **Goal:** Export home directories for LDAP users.
 
-Utilize the SIMP profile module ``simp_nfs``:
+Utilize the SIMP profile module ``simp-simp_nfs``:
 
-#. ``simp_nfs``: Manages client and server configurations for managing NFS home
-   directories.
-#. ``simp_nfs::create_home_dirs``: Optional hourly cron job that binds to a
-   :term:`LDAP` server, ``simp_options::ldap::uri`` by default, and creates a
-   NFS home directory for all users in the LDAP server. Also expires any home
-   directories for users that no longer exist in LDAP.
+#. ``simp-simp_nfs``: Manages client and server configurations for managing NFS
+   home directories.
+#. ``simp_nfs::create_home_dirs``: Enables an optional hourly cron job that
+   binds to a :term:`LDAP` server, ``simp_options::ldap::uri`` by default, and
+   creates a NFS home directory for all users in the LDAP server. It also
+   expires any home directories for users that no longer exist in LDAP.
 
 .. NOTE::
 
@@ -246,27 +299,31 @@ Utilize the SIMP profile module ``simp_nfs``:
 
 .. NOTE::
 
-   The simp_nfs module utilizes an NFS root mount which must be used to export
-   any further directories from this server.
+   The ``simp-simp_nfs module`` utilizes an NFS root share which must be used
+   to export any further directories from this server using NFSv4. This is
+   because NFSv4 exports must exist in a single pseudo filesystem.
    See :ref:`Additional_Directories` for an example of how to do this.
 
 Client
 ^^^^^^
 
-The following block of code should be entered in the Hiera YAML files of all
-systems that need to mount home directories.  The ``default.yaml`` file will
-affect all systems.
+The following should be entered in the Hiera YAML files of all servers that
+need to mount home directories.  Use *data/default.yaml* if you want to mount
+the home directories on all servers.
 
 .. code-block:: yaml
 
-   nfs::is_server: false
-   simp_nfs::home_dir_server: <your nfs server>
+   simp_nfs::home_dir_server: <your NFS server IP>
 
    simp::classes:
      - simp_nfs
 
 Server
 ^^^^^^
+
+The following should be entered in the Hiera YAML file of the NFS server.
+
+In *data/hosts/<your NFS server FQDN>.yaml*:
 
 .. code-block:: yaml
 
@@ -278,65 +335,73 @@ Server
 
 .. _Additional_Directories:
 
-Exporting additional directories on the NFS home server
+Exporting Additional Directories on the NFS Home Server
 -------------------------------------------------------
 
-**Goal:** Export ``/var/nfs/share1`` located on the server which is also
-sharing home directories set up by the ``simp-simp_nfs`` module.  Mount the
-share to ``/share`` on client systems.
+**Goal:**
 
-The ``simp-simp_nfs`` module utilizes a NFS root share.  Any directories
-shared out in addition to the home directories must be mounted to the NFS root
-and shared from there.  To see how the NFS root is created see the
-``simp_nfs::export::home`` documentation.
+* Export */var/nfs/share1* for read-write access to the 'administrators'
+  group
+
+  * This directory is located on the NFS server which is also sharing home
+    directories for LDAP users.
+  * The home directory share is set up by the ``simp-simp_nfs`` module.
+
+* Statically mount the share to */share* on client systems.
+
+The ``simp-simp_nfs`` module exports home directories under a root NFS
+share directory. Because NFSv4 exports exist in a single pseudo filesystem,
+each directory below that NFS share should be a bind mount to a directory on
+the NFS server.
 
 The following example assumes you have set up the home server already following
-the instructions in the previous section.
+the instructions in the previous section and will be creating a bind mount under
+the root NFS share directory.
 
 Server
 ^^^^^^
 
-Create a manifest in your :term:`site profile`. In this example the site
-profile module is ``site`` and the manifest ``nfs_server.pp``
+Create a manifest in your :term:`site profile`. In this example the manifest
+and the ``site`` module is *nfs_server.pp*.
 
-``site/manifest/nfs_server.pp``;
+In *site/manifest/nfs_server.pp*:
 
 .. code-block:: puppet
 
    class site::nfs_server (
-   #  Make sure the data_dir is the same as in simp_nfs.
-   Stdlib::Absolutepath                             $data_dir     = '/var',
-   Simplib::Netlist                                 $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
-   Array[Enum['none','sys','krb5','krb5i','krb5p']] $sec = ['sys'],
+     #  Make sure the data_dir is the same as in simp_nfs.
+     Stdlib::Absolutepath                             $data_dir     = '/var',
+     Simplib::Netlist                                 $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
+     Array[Enum['none','sys','krb5','krb5i','krb5p']] $sec = ['sys'],
    ) {
 
-   #
-   #  Exporting directories from the home directory server when
-   #  using the simp_nfs module.
-   #
+     #
+     #  Exporting directories from the home directory server configured
+     #  with the simp_nfs module.
+     #
      include nfs::server
 
-   # Create the directory where the data exists.
+     # Create the directory where the data exists.
      file { '/var/nfs/share1':
        ensure => 'directory',
-       mode   => '0755',
+       mode   => '0775',
        owner  => 'root',
-       group  => 'root'
+       group  => 'administrators'
      }
 
-   # Create a mount point under the nfs root created in simp_nfs.
+     # Create a mount point under the NFS root share created in simp_nfs.
      file { "${data_dir}/nfs/exports/share1":
        ensure => 'directory',
-       mode   => '0755',
+       mode   => '0775',
        owner  => 'root',
-       group  => 'root'
+       group  => 'administrators'
      }
 
-   # Mount the share to the nfs_root created in simp_nfs.
+     # Bind mount the share to the NFS root share created in simp_nfs.
      mount { "${data_dir}/nfs/exports/share1":
        ensure   => 'mounted',
        fstype   => 'none',
-       device   => "/var/nfs/share1",
+       device   => '/var/nfs/share1',
        remounts => true,
        options  => 'rw,bind',
        require  => [
@@ -345,16 +410,18 @@ profile module is ``site`` and the manifest ``nfs_server.pp``
        ]
      }
 
-   # Export the directory
+     # Export the directory
      if !$nfs::stunnel {
        nfs::server::export { 'share1':
-         clients     => nets2cidr($trusted_nets),
+         clients     => $trusted_nets,
          export_path => "${data_dir}/nfs/exports/share1",
          rw          => true,
          sec         => $sec
        }
      } else {
          nfs::server::export { 'share1':
+         # From the NFS server's perspective, the stunneled connections will
+         # come from the local host
          clients     => ['127.0.0.1'],
          export_path => "${data_dir}/nfs/exports/share1",
          rw          => true,
@@ -364,11 +431,10 @@ profile module is ``site`` and the manifest ``nfs_server.pp``
      }
    }
 
-Include this manifest in the servers Hiera file.
+In *data/hosts/<your NFS server FQDN>.yaml*:
 
 .. code-block:: yaml
 
-   ---
    nfs::is_server: true
 
    simp::classes:
@@ -378,10 +444,10 @@ Include this manifest in the servers Hiera file.
 Client
 ^^^^^^
 
-Create a manifest in your :term:`site profile`. In this example the site
-profile module is ``site`` and the manifest ``nfs_client.pp``
+Create a manifest in your :term:`site profile`. In this example the manifest
+in the ``site`` module is *nfs_client.pp*.
 
-``site/manifests/nfs_client.pp``
+In *site/manifests/nfs_client.pp*:
 
 .. code-block:: puppet
 
@@ -394,31 +460,25 @@ profile module is ``site`` and the manifest ``nfs_client.pp``
 
      $mount_point = '/share'
 
-     # Since it the nfs server uses a nfs_root, you only put the path
-     # relative to the root.
+     # Only need the path relative to the root of the NFSv4 pseudo filesystem.
      $remote_path = '/share1'
 
 
-     if getvar('::nfs::client::is_server') {
-       $_target = '127.0.0.1'
-     }
-     else {
-       $_target = $nfs_server
-     }
-
-     file { "${mount_point}":
+     file { $mount_point:
        ensure => 'directory',
-       mode   => '0755',
+       mode   => '0775',
        owner  => 'root',
+       group  => 'administrators'
      }
 
-     nfs::client::mount { "${mount_point}":
-       nfs_server         => $nfs_server,
-       remote_path        => $remote_path,
-       nfs_version        => 'nfs4',
-       sec                => $sec,
-       autofs             => false,
-       at_boot            => true,
+     nfs::client::mount { $mount_point:
+       nfs_server  => $nfs_server,
+       remote_path => $remote_path,
+       sec         => $sec,
+       autofs      => false,
+       at_boot     => true,
+       # The mount point must already exist in a static mount
+       require     => File[$mount_point]
      }
    }
 
@@ -427,9 +487,7 @@ share.
 
 .. code-block:: yaml
 
-   ---
-   nfs::is_server: false
-   site::nfs_client::nfs_server: server21.simp.test
+   site::nfs_client::nfs_server: <your NFS server IP>
 
    simp::classes:
      - site::nfs_client
@@ -443,21 +501,11 @@ Stunnel is a means to encrypt your NFS data during transit.
 Enable
 ^^^^^^
 
-If ``simp_options::stunnel`` is set to ``true``, you need only specify the
-following, in the server's :term:`YAML` file:
-
-.. NOTE::
-
-   The following is set to prevent a cyclical connection of stunnel to itself,
-   in the event the server is a client of itself.
-
-.. code-block:: yaml
-
-   nfs::client::stunnel::nfs_server: <your nfs server>
+If ``simp_options::stunnel`` is set to ``true``, ``stunnel`` will be enabled.
 
 If ``simp_options::stunnel`` is set to ``false`` and you do not wish to
-globally enable ``stunnel``, you will also need to set the following, in
-``default.yaml``:
+globally enable ``stunnel``, you will need to set the following, in
+*data/default.yaml*:
 
 .. code-block:: yaml
 
@@ -467,7 +515,7 @@ Disable
 ^^^^^^^
 
 If ``simp_options::stunnel`` is set to ``true``, but you do not want your NFS
-traffic to go through ``stunnel``, set the following, in ``default.yaml``:
+traffic to go through ``stunnel``, set the following, in *data/default.yaml*:
 
 .. code-block:: yaml
 
@@ -476,50 +524,6 @@ traffic to go through ``stunnel``, set the following, in ``default.yaml``:
 If ``simp_options::stunnel`` is set to ``false`` then ``stunnel`` is already
 disabled.
 
-Enabling Kerberos
------------------
-
-.. WARNING::
-
-   This functionality is incomplete. It does not work with home directories.
-   See ticket `SIMP-1407`_.
-
-In addition to the sharing code (not the ``stunnel`` code) above, add the
-following:
-
-default.yaml
-^^^^^^^^^^^^
-
-.. code-block:: yaml
-
-   simp::classes:
-     - 'krb5::keytab'
-
-   nfs::secure_nfs: true
-   simp_options::krb5: true
-
-   krb5::kdc::auto_keytabs::global_services:
-     - 'nfs'
-
-Server
-^^^^^^
-
-.. code-block:: yaml
-
-   simp::classes:
-     - 'krb5::kdc'
-
-Clients
-^^^^^^^
-
-.. code-block:: yaml
-
-   nfs::is_server: false
-
-   simp::classes:
-     - 'simp_nfs'
-
+.. _README: https://github.com/simp/pupmod-simp-nfs/blob/7.0.0/README.md
 .. _SIMP-1407: https://simp-project.atlassian.net/browse/SIMP-1407
-.. _SIMP-2944: https://simp-project.atlassian.net/browse/SIMP-2944
-.. _autofs-5.0.5-122: http://vault.centos.org/6.8/os/x86_64/Packages/autofs-5.0.5-122.el6.x86_64.rpm
 .. _autofs-5.0.7-56: http://vault.centos.org/7.3.1611/os/x86_64/Packages/autofs-5.0.7-56.el7.x86_64.rpm

--- a/docs/user_guide/HOWTO/Redundant_LDAP.rst
+++ b/docs/user_guide/HOWTO/Redundant_LDAP.rst
@@ -87,7 +87,7 @@ Hiera, for example: ``data/hosts/ldap_server1.your.domain.yaml``:
 
 .. code-block:: yaml
 
-   classes :
+   simp::classes:
      - 'simp::server::ldap'
 
 Leave any other classes that are there if they are needed. Run the Puppet
@@ -124,7 +124,7 @@ three things, add the following lines to the
    simp::server::ldap::is_consumer: true
    simp::server::ldap::rid: 888
 
-   classes :
+   simp::classes:
      - 'simp::server::ldap'
 
 .. _URI:
@@ -178,7 +178,7 @@ Place this file in the ``site`` module's  ``manifests/`` directory using the nam
 
 .. code-block:: yaml
 
-   classes :
+   simp::classes:
      - 'site::ldap_consumer'
 
 

--- a/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
+++ b/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
@@ -74,8 +74,9 @@ This example creates a ``local_system_access`` :term:`Puppet module` in the
 
    .. code-block:: sh
 
-      mkdir -p /etc/puppetlabs/code/environments/production/modules/local_system_access/manifests
-      cd /etc/puppetlabs/code/environments/production/modules/local_system_access
+      cd /etc/puppetlabs/code/environments/production/modules
+      mkdir -p local_system_access/manifests
+      cd local_system_access
 
 #. Add the following to a new ``manifests/local_user.pp`` file to enable ``sudo su - root``
    and allow ``ssh`` access for the user you created/selected:
@@ -89,7 +90,8 @@ This example creates a ``local_system_access`` :term:`Puppet module` in the
         sudo::user_specification { 'default_userx':
           user_list => ['userx'],
           runas     => 'root',
-          passwd    => false,   # ONLY NEEDED IF YOUR USER DOES NOT USE A PASSWORD
+          # ONLY NEEDED IF YOUR USER DOES NOT USE A PASSWORD
+          passwd    => false,
           cmnd      => ['/bin/su root', '/bin/su - root']
         }
 
@@ -99,7 +101,7 @@ This example creates a ``local_system_access`` :term:`Puppet module` in the
           pam::access::rule { 'allow_userx':
             users   => ['userx'],
             origins => ['ALL'],
-            comment => 'The local user, used to remotely login to the system in the case of a lockout.'
+            comment => 'Local user for lockout prevention'
           }
         }
       }


### PR DESCRIPTION
Added:
  * Modified the NFS documentation to warn about breaking changes in
    version 7 of simp-nfs and simp-autofs
Fixed:
  * Fixed some code examples
  * Directly linked to SIMP support tickets
Notes:
  * Validated that the NFS and Autofs updates in the changelog for 6.5.0
    reflect the breaking changes well

SIMP-8377 #close