### PR TITLE
(SIMP-8456) Prevent lockout instructions are incorrect

### DIFF
--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -295,8 +295,8 @@ is now available.
 
 .. IMPORTANT::
 
-   Be aware that ``firewalld`` rules do not support hostnames. IP addresses
-   must be used. This may impact your use of any manifests that contain
+   Be aware that ``firewalld`` rules do not support hostnames; IP addresses
+   must be used. This may impact any manifests that contain
    ``iptables::listen::*`` resources, including resources from some SIMP
    modules. You will have to change hostnames to IP addresses for the
    affected resources when using ``firewalld``.
@@ -1668,4 +1668,3 @@ Nothing significant at this time.
 The SIMP project in JIRA can be used to `file bugs`_.
 
 .. _file bugs: https://simp-project.atlassian.net
-

--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -275,22 +275,31 @@ firewalld Support
 As of SIMP 6.5.0, preliminary ``firewalld`` support within the SIMP ecosystem
 is now available.
 
-* *New simp-simp_firewalld module*: SIMP now includes ``simp-simp_firewalld``
+* **New simp-simp_firewalld module**: SIMP now includes ``simp-simp_firewalld``
   which provides a profile class and defined type to manage the system's
   ``firewalld`` with "safe" defaults and safety checks for ``firewalld`` rules.
-* *firewalld support in simp-iptables for backward compatibility*:  The
+* **firewalld support in simp-iptables for backward compatibility**:  The
   ``simp-iptables`` module has preliminary support for acting as a pass-through
-  to various ``firewalld`` capabilities using the ``simp/simp_firewalld``
+  to various ``firewalld`` capabilities using the ``simp-simp_firewalld``
   module.
 
   * To enable ``firewalld`` mode on supported operating systems, simply set
     ``iptables::use_firewalld`` to ``true`` via Hiera.
   * EL8 systems enable ``firewalld`` mode by default.
   * Use of any of the ``iptables::listen::*`` defined types will work
-    seamlessly in ``firewalld`` mode.
+    seamlessly in ``firewalld`` mode, as long as IP addresses are used
+    in their ``trusted_net`` parameters.
   * Direct calls to ``iptables::rule`` in ``firewalld`` mode will emit
     a warning notification that directs the user to convert their rules to
     ``simp_iptables::rule`` types.
+
+.. IMPORTANT::
+
+   Be aware that ``firewalld`` rules do not support hostnames. IP addresses
+   must be used. This may impact your use of any manifests that contain
+   ``iptables::listen::*`` resources, including resources from some SIMP
+   modules. You will have to change hostnames to IP addresses for the
+   affected resources when using ``firewalld``.
 
 Optional Dependency Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -342,19 +351,19 @@ Puppet RPMs
 
 The following Puppet RPMs are packaged with the SIMP 6.5.0 ISOs:
 
-+----------------------+-----------+
-| Package              | Version   |
-+======================+===========+
-| ``puppet-agent``     | 6.18.0-1  |
-+----------------------+-----------+
-| ``puppet-bolt``      | 2.29.0-1  |
-+----------------------+-----------+
-| ``puppetdb``         | 6.12.0-1  |
-+----------------------+-----------+
-| ``puppetdb-termini`` | 6.12.0-1  |
-+----------------------+-----------+
-| ``puppetserver``     | 6.13.0-1  |
-+----------------------+-----------+
++----------------------+----------+
+| Package              | Version  |
++======================+==========+
+| ``puppet-agent``     | 6.18.0-1 |
++----------------------+----------+
+| ``puppet-bolt``      | 2.29.0-1 |
++----------------------+----------+
+| ``puppetdb``         | 6.12.0-1 |
++----------------------+----------+
+| ``puppetdb-termini`` | 6.12.0-1 |
++----------------------+----------+
+| ``puppetserver``     | 6.13.0-1 |
++----------------------+----------+
 
 .. WARNING::
 
@@ -936,7 +945,7 @@ pupmod-simp-iptables
 ^^^^^^^^^^^^^^^^^^^^
 
 * Added preliminary support for acting as a pass-through to various
-  ``firewalld`` capabilities using the ``simp/simp_firewalld`` module.
+  ``firewalld`` capabilities using the ``simp-simp_firewalld`` module.
 
   * Using any of the ``iptables::listen::*`` defined types will work seamlessly
     in ``firewalld`` mode but direct calls to ``iptables::rule`` will fail.

--- a/docs/user_guide/HOWTO/Disable_Ssh.rst
+++ b/docs/user_guide/HOWTO/Disable_Ssh.rst
@@ -32,7 +32,7 @@ connections to ``sshd``.  However, if the ``svckill`` class (from the
 ``simp-svckill`` Puppet module) is also included in your SIMP scenario, it
 will *not* automatically kill ``sshd`` when you cease management of the SSH
 configuration. This is because ``sshd`` has been whitelisted by
-``svckill::ignore_default``.  So, if you want ``svckill`` to kill running
+``svckill::ignore_defaults``.  So, if you want ``svckill`` to kill running
 ``sshd`` services, you must add the following to your Hiera configuration:
 
 .. code-block::  yaml

--- a/docs/user_guide/Initial_Server_Configuration.rst
+++ b/docs/user_guide/Initial_Server_Configuration.rst
@@ -14,7 +14,7 @@ options of the ``simp`` command
 For a list of the commands ``simp`` provides, type ``simp help``. Type
 ``simp <Command> --help`` for more information on a specific command.
 
-- ``simp config`` sets up configuration required to bootstrap the SIMP server
+* ``simp config`` sets up configuration required to bootstrap the SIMP server
   with Puppet.  It asks questions, generates configuration files, and applies
   preliminary server configuration based on the answers.  It records the options
   chosen in a file, ``/root/.simp/simp_conf.yaml`` and generates a log file
@@ -28,7 +28,7 @@ For a list of the commands ``simp`` provides, type ``simp help``. Type
     default. If you want to use a different intial environment, see
     :ref:`howto-use-an-alternate-simp-config-environment`.
 
-- ``simp bootstrap`` uses several targeted Puppet runs to configure the rest
+* ``simp bootstrap`` uses several targeted Puppet runs to configure the rest
   of the system and generates a log file under ``/root/.simp/``.
 
 For more details about initial configuration provided by ``simp config`` see
@@ -39,118 +39,102 @@ Configuring the SIMP Server
 
 .. WARNING::
 
-   Puppet has problems when hostnames contain capital letters
-   (`SERVER-1809`_) — do not use them!
+   Puppet has problems when hostnames contain capital letters (`SERVER-1809`_) — do not use them!
 
    .. _SERVER-1809: https://tickets.puppetlabs.com/browse/SERVER-1809
 
-#. Log on as a user that can gain ``root`` access and ``su`` to ``root``.
+#. Log on as a user that can gain ``root`` access and ``sudo`` to ``root``.
 
-   - If you installed from the ISO, it created the ``simp`` user.
-     Log in with ``simp`` and run  ``su -``.
-   - If you installed from RPM, create a privileged user or log in as ``root``.
-     There will be instructions later about how to configure access for the
-     privileged user on the SIMP server, so that after bootstrap, you are not
-     locked out of the server.  This step is **essential** on cloud instances.
+   * **If you installed from the ISO**
 
-#. Run ``simp config`` and configure the system as prompted.  (The ``--dry-run``
-   option will run through all of the prompts without applying any changes to
-   the system.)
+     * Log in as ``simp``.
+     * Run  ``sudo su - root``.
 
-   -  ``simp config`` will prompt you with the follow:
+   * **If you installed from RPM**
 
-      - ``Ready to create the SIMP omni-environment?`` Enter ``yes``.
-      - ``Ready to start the questionnaire?`` Enter ``yes``.
+     * Create a local user that can escalate to ``root`` and use it to access the ``root`` account.
 
-   -  ``simp config`` will then prompt you for system settings and apply them as
-      appropriate for bootstrapping the system. When applicable, ``simp config``
-      will present you with a recommendation for each setting. For each question:
+#. Run ``simp config`` and configure the system as prompted.
 
-      - Press *Enter* to keep a recommended value.
-      - Otherwise, enter your desired value.
+   * These settings will be used to set up files appropriate for bootstrapping the system.
 
-   -  When the questionnaire is finished and you are prompted with
+     * For each setting:
 
-      -  ``Ready to apply?`` Enter ``yes`` to continue.
+       * Press *Enter* to keep the recommended value or enter your desired value.
 
-   -  ``simp config`` then applies the information and generates its
-      configuration files.
+  * For more details about ``simp config``'s installation variables and actions, see
+    :ref:`gsg-advanced-configuration`.
 
+  .. NOTE::
 
-      .. Important::
+     If you see a message about 'simp bootstrap' being 'locked', follow the steps in
+     :ref:`ug-prevent-lockout`:
 
-         If you have installed SIMP from RPM and see the following failure, go
-         to the :ref:`ug-prevent-lockout`  section and follow the steps to
-         configure a user that has ``su -`` capability.
+.. _ug-initial_server_configuration-run_bootstrap:
 
-           ``'simp bootstrap' has been locked due to potential login lockout.``
+3. Run ``simp bootstrap``.
 
-             ``* See /root/.simp/simp_bootstrap_start_lock for details``
+   If your SIMP server is on a virtual machine, or slow system, the default timeout for the
+   Puppet server to start (5 minutes) may be too short.  You will want to extend this time by using
+   the ``-w`` option.
 
-   - For more details about ``simp config``'s installation variables and
-     actions, see :ref:`gsg-advanced-configuration`.
+   For example, to extend the timeout to 10 minutes:
 
+   .. code:: bash
 
-#. Run ``simp bootstrap``.
-
-   If your SIMP server is a virtual machine in a cloud, the default
-   timeout for the Puppet server to start (5 minutes) may be too short.
-   You will want to extend this time by using the ``-w`` option.  For
-   example, to extend that timeout to 10 minutes:
-
-   ``simp bootstrap -w 10``
-
+      $ simp bootstrap -w 10
 
    .. NOTE::
 
-      If the bootstrap finishes quickly and the progress bars of each Puppet run
-      are of equal length, it is very likely that  a problem has occurred due to
-      an error in SIMP configuration. Refer to the previous step and make sure
-      that all configuration options are correct.
+      If the bootstrap progress bars of each Puppet run are of equal length, a problem has probably
+      occurred due to an error in SIMP configuration. Refer to the previous step and make sure that
+      all configuration options are correct.
 
-      If this happens, you can debug by either looking at the log files or by
-      running ``puppet agent -t --masterport=8150``.
+      You can debug issues by either looking at the log files in ``/root/.simp`` or by running
+      ``puppet agent -t --masterport=8150``.
 
 #. Run ``reboot`` to restart your system and apply the necessary kernel
    configuration items.
 
+After rebooting, SIMP-managed security settings have been applied and the SIMP server is ready for
+site-specific configuration.
 
-When your systems comes back up, SIMP-managed security settings have been applied
-and the SIMP server (``puppetserver``) is ready for site-specific configuration.
-To ``su`` to ``root`` from the  ``simp`` user, you must now use ``sudo su -t root``.
+To ``su`` to ``root`` from the  ``simp`` user, you must now use ``sudo su - root``.
 
-Next steps:
+Next Steps
+----------
 
-* To continue configuring the system, move on to the next section in the
-  :ref:`simp-user-guide`, :ref:`Client_Management`.
-* To learn more details about what the ``simp`` utility just did to your system,
-  see :ref:`gsg-advanced-configuration`.
+* To continue configuring the system, move on to the next section in the :ref:`simp-user-guide`,
+  :ref:`Client_Management`.
+* To learn more details about how your system has just been configured see :ref:`gsg-advanced-configuration`.
 
-Optional: Extract the full OS RPM Package Set
+Optional: Extract the Full OS RPM Package Set
 ---------------------------------------------
 
-The SIMP ISO only provides enough RPM packages to run a basic system. If you
-require additional stock OS packages, you can extract additional packages from
-vendor ISOs using the following procedure:
+The SIMP ISO provides a minimal set of packages.
 
-#. Log on as ``simp`` and run ``su -`` to gain root access.
+If you require additional OS packages, you can extract them from vendor ISOs using the following
+procedure:
+
+#. Log on as ``simp`` and run ``sudo su - root``.
 #. Run ``puppet agent -t`` to ensure system consistency.
 #. Copy the appropriate vendor OS ISO(s) to the server and unpack using the
    ``unpack_dvd`` utility. This will create a new directory tree under
    ``/var/www/yum/<OperatingSystem>`` suitable for serving to clients.
 
-   Run: ``unpack_dvd CentOS-RHEL_MAJOR_VERSION-x86_64-DVD-####.iso``
+   .. code:: bash
+
+      $ unpack_dvd CentOS-RHEL_MAJOR_VERSION-x86_64-DVD-####.iso
 
    .. WARNING::
 
-      If the server where you are unpacking the vendor ISO was **not** built
-      using the SIMP ISO , you will need to also unpack the associated SIMP ISO
-      using the ``unpack_dvd`` utility.
+      If the server where you are unpacking the vendor ISO was **NOT** built using the SIMP ISO ,
+      you must also unpack the associated SIMP ISO using the ``unpack_dvd`` utility.
 
 #. Ensure that subsequent :term:`yum` operations are aware of the new RPM
    packages by refreshing the system's yum cache:
 
-   Run: ``yum clean all; yum makecache``
+   Run: ``yum clean all && yum makecache``
 
 .. include::  Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
 

--- a/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
+++ b/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
@@ -3,145 +3,171 @@
 Prevent Lockout from the SIMP Server during RPM Installation
 ------------------------------------------------------------
 
-Per security policy, SIMP, by default, disables login via ``ssh`` for all users,
-including ``root``, and beginning with SIMP 6.0.0, disables ``root`` logins at
-the console by default.  So, if one of the following scenarios applies, you
-should configure a local user for this server to have both ``su`` and ``ssh``
-privileges, in order to prevent lockout from the system:
+By default, SIMP:
 
-* Console access is available but not allowed for ``root`` and no other
-  administrative user account has yet been created.
+  * Disables remote logins for all users.
+  * Disables ``root`` logins at the console.
 
-  * This can happen when SIMP is installed from RPM and the user accepts
-    ``simp config``'s default value for ``useradd:securetty`` (an empty array).
+If one of the following scenarios applies, you must enable ``sudo`` and ``ssh`` access for a local
+user. If you do not do this, you may lose access to your system.
 
-* Both console access is not available and the administrative user's ``ssh``
-  access has not yet been enabled (permanently) via Puppet.
+**Scenario 1:**
 
-  * This can happen when SIMP is installed from RPM on cloud systems.
+  * Console access is available, but not allowed, for ``root`` and no other
+    user account is available.
 
-``simp config`` will issue a warning if it thinks this situation may be
-possible and writes a lock file to prevent ``simp bootstrap`` from running.
-The warning looks like:
+    * This generally occurs when SIMP is installed from RPM and the user accepts
+      ``simp config``'s default value for ``useradd:securetty`` (an empty array).
 
-|  ``'simp bootstrap' has been locked due to potential login lockout.``
-|  ``* See /root/.simp/simp_bootstrap_start_lock for details``
+**Scenario 2:**
 
+  * Console access is not available and the administrative user's ``ssh``
+    access has not yet been enabled permanently via Puppet.
 
-If you have access to the console, have the ``root`` password, and have enabled
-``root`` console access by setting ``useradd::securetty`` in :term:`Hiera` to a
-valid tty (e.g., ``tty0``), the login lockout warning is not applicable. After
-you address any other issues identified in ``/root/.simp/simp_bootstrap_start_lock``
-(see :ref:`ug-other-bootstrap-lock-issues`), you can simply remove the file and
-continue with the bootstrap process.
+    * This generally occurs when SIMP is installed from RPM on cloud systems.
 
-Otherwise, follow the instructions in the subsections below to create a local
-user who can successfully access the system and sudo to ``root``.
+In either of these scenarios ``simp config`` will issue the following warning
+and write a lock file to prevent ``simp bootstrap`` from running.
+
+::
+
+  'simp bootstrap' has been locked due to potential login lockout.
+  * See /root/.simp/simp_bootstrap_start_lock for details
+
+This remainder of this document provides instructions on creating a local user that has the
+appropriate level of system access.
+
+After you address all issues identified in
+``/root/.simp/simp_bootstrap_start_lock`` (see :ref:`ug-other-bootstrap-lock-issues`),
+you should remove the file and
+:ref:`continue with the bootstrap process<ug-initial_server_configuration-run_bootstrap>`.
 
 
 Configure Local User for Access
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This example creates a manifest in a local module, ``mymodule``, in the
-``production`` Puppet environment.  See `Puppet module documentation`_ for
-information on how to create a Puppet module.
+This example creates a ``local_system_access`` :term:`Puppet module` in the
+``production`` :term:`Puppet environment`.
 
-This example also assumes you are logged in as ``root``.
+* **If you already have an unprivileged account:**
 
-#. Create a local user account, as needed, using ``useradd``.  This example
-   assumes the local user is ``userx``.
+   * Replace ``userx`` with your current **non-root** username throughout the
+     example code.
 
-   * Be sure to set the user's password if the user is logging in with a password.
-   * SIMP is configured to create a home directory for the user, if it does
-     not exist when the user first logs in.
+* **If you do NOT already have an unprivileged account:**
 
-#. Create a ``local_user.pp`` manifest in ``mymodule/manifests`` to enable
-   ``sudo su - root`` and allow ``ssh`` access for the user you created/selected:
+   * Create a local user account, using ``useradd``.
 
-   a. Create the ``mymodule`` module directory and its ``manifests`` sub-directory
+     * This example assumes the local user is named ``userx``.
+     * Be sure to set the user's password if the user is logging in with a password!
 
-      .. code-block:: sh
 
-         $ mkdir -p /etc/puppetlabs/code/environments/production/modules/mymodule/manifests
+#. Run ``sudo su - root``
 
-   b. Create ``mymodule/manifests/local_user.pp`` with the following content:
+#. Set your ``umask``.
 
-      .. code-block:: ruby
+   .. code-block:: sh
 
-         class mymodule::local_user (
-           Boolean $pam = simplib::lookup('simp_options::pam', { 'default_value' => false }),
-         ) {
+      $ umask 022
 
-           sudo::user_specification { 'default_userx':
-             user_list => ['userx'],
-             runas     => 'root',
-          #   passwd    => false,   # only needed if user logs in without a password
-             cmnd      => ['/bin/su root', '/bin/su - root']
-           }
+#. Create a ``local_system_access`` puppet module directory and change to the directory.
 
-           if $pam {
-             include 'pam'
+   .. code-block:: sh
 
-             pam::access::rule { 'allow_userx':
-               users   => ['userx'],
-               origins => ['ALL'],
-               comment => 'The local user, used to remotely login to the system in the case of a lockout.'
-             }
-           }
-         }
+      $ mkdir -p /etc/puppetlabs/code/environments/production/modules/local_system_access/manifests
+      $ cd /etc/puppetlabs/code/environments/production/modules/local_system_access
 
-   #. Uncomment out the ``passwd`` line in ``sudo::user_specification`` if the local
-      user is configured to login with pre-shared keys instead of a password
-      (typical cloud configuration).
+#. Add the following to a new ``manifests/local_user.pp`` file to enable ``sudo su - root``
+   and allow ``ssh`` access for the user you created/selected:
 
-#. Create a ``mymodule/metadata.json`` file.
+   .. code-block:: ruby
 
-   * See `Puppet metadata documentation`_ for more information on metadata.json files.
-   * It should look something like the following:
+      class local_system_access::local_user (
+        Boolean $pam = simplib::lookup('simp_options::pam', { 'default_value' => false }),
+      ) {
+
+        sudo::user_specification { 'default_userx':
+          user_list => ['userx'],
+          runas     => 'root',
+          passwd    => false,   # ONLY NEEDED IF YOUR USER DOES NOT USE A PASSWORD
+          cmnd      => ['/bin/su root', '/bin/su - root']
+        }
+
+        if $pam {
+          include 'pam'
+
+          pam::access::rule { 'allow_userx':
+            users   => ['userx'],
+            origins => ['ALL'],
+            comment => 'The local user, used to remotely login to the system in the case of a lockout.'
+          }
+        }
+      }
+
+#. Add the following to a new ``metadata.json`` file to enable proper
+   recognition of your module by the puppet server:
 
    .. code-block:: yaml
 
-     {
-       "name": "mymodule",
-       "version": "0.0.1",
-       "author": "Your name or group here",
-       "summary": "Configures Local User for sudo access",
-       "license": "Apache-2.0",
-       "source": "Your gitlab url or local",
-       "dependencies": [
-         {
-           "name": "simp/pam"
-         },
-         {
-           "name": "simp/simplib"
-         },
-         {
-           "name": "simp/sudo"
-         }
-       ]
-     }
+      {
+        "name": "local_system_access",
+        "version": "0.0.1",
+        "author": "Your name or group here",
+        "summary": "Configures Local User for sudo access",
+        "license": "Apache-2.0",
+        "source": "Your gitlab url or local",
+        "dependencies": [
+          {
+            "name": "simp/pam"
+          },
+          {
+            "name": "simp/simplib"
+          },
+          {
+            "name": "simp/sudo"
+          }
+        ]
+      }
+
+   * See the `Puppet metadata documentation`_ for more information on metadata.json files.
 
 #. Make sure the permissions are correct on the module:
 
    .. code-block:: bash
 
-      $ chown -R root:puppet  /etc/puppetlabs/code/environments/production/modules/mymodule
-      $ chmod -R g+rX  /etc/puppetlabs/code/environments/production/modules/mymodule
+      $ chown -R root:puppet $PWD
+      $ chmod -R g+rX $PWD
 
 #. Add the module to the SIMP server's host YAML file class list:
 
-   Edit the SIMP server's YAML file,
-   ``/etc/puppetlabs/code/environments/production/data/hosts/<SIMP server FQDN>.yaml``
-   and add the ``mymodule::local_user`` to the ``simp::classes`` array:
+   .. code-block:: bash
+
+      $ cd /etc/puppetlabs/code/environments/production/data/hosts
+
+   Add ``local_system_access::local_user`` to the ``simp::classes:`` array in ``<SIMP server FQDN>.yaml``
 
    .. code-block:: yaml
 
       simp::classes:
-        - mymodule::local_user
+        - local_system_access::local_user
+        # Do NOT remove other items in this array
+        # Make sure your whitespace lines up (spaces, not tabs)
 
-#. If the local user is configured to login with pre-shared keys instead of a
-   password (typical cloud configuration), copy the ``authorized_keys`` file for
-   that user to the SIMP-managed location for authorized keys ``/etc/ssh/local_keys``:
+#. Add the ``local_system_access`` module to the ``Puppetfile`` in the ``production`` environment:
+
+   Edit ``/etc/puppetlabs/code/environments/production/Puppetfile``, and add the
+   following line under the section that says *"Add your own Puppet modules here"*
+
+   .. code-block:: ruby
+
+      mod 'local_system_access', :local => true
+
+
+If Your Local User Uses an SSH Public Key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* If the local user has an SSH public key available, copy the ``authorized_keys`` file for
+  that user to the SIMP-managed location for authorized keys ``/etc/ssh/local_keys`` as shown below:
 
    .. code-block:: bash
 
@@ -151,72 +177,67 @@ This example also assumes you are logged in as ``root``.
       $ chmod 644 /etc/ssh/local_keys/userx
 
 
-#. Add the module to the ``Puppetfile`` in the ``production`` environment:
-
-   Edit the ``Puppetfile`` used to deploy the modules,
-   ``/etc/puppetlabs/code/environments/production/Puppetfile``,  and add a line
-   under the section that says "Add you own Puppet modules here"
-
-   .. code-block:: yaml
-
-      mod 'mymodule', :local => true
-
-
 .. _ug-other-bootstrap-lock-issues:
 
-Resolve Other Issues in Bootstrap Lock File
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Resolve Other Issues in the Bootstrap Lock File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The bootstrap lock file can identify other issues, in addition to user lockout.
 If any other issues are identified in ``/root/.simp/simp_bootstrap_start_lock``,
-address those issues before removing the file.
+you must address them before removing the file.
 
   * Currently, the only other issue ``simp config`` will identify is a possible
     misconfiguration of YUM repositories. ``simp config`` will lock out
     bootstrap if it cannot find a few of the key packages needed for
-    bootstrapping.  Fix your yum repository configuration and then verify the
+    bootstrapping. Fix your yum repository configuration and then verify the
     fix using the verification instructions in the lock message.
 
 Resume Bootstrap Operation and Verify User Access
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. IMPORTANT::
+.. WARNING::
 
-   DO NOT REBOOT BEFORE VERIFYING USER ACCESS
+   **DO NOT REBOOT BEFORE VERIFYING USER ACCESS USING AN ALTERNATE TERMINAL OR SSH SESSION**
 
-#. Remove ``/root/.simp/simp_bootstrap_start_lock``.
-#. Run ``simp bootstrap``.
-#. Run ``puppet agent -t`` to verify that there are no warning or error
-   messages related to ``mymodule``.
+#. Remove the lock file and bootstrap the system
 
-   * You will see a reboot notification which is expected and not an issue.
-   * You may see warning/errors related to other modules that manage
-     services you have not completely set up, such as ``named``. These are
-     expected.
-   * You may see ``svckill`` warnings about services found that would
-     be killed if ``svckill::mode`` was set to 'enforcing'. You can
-     address those later, after you have examined those services and
-     determined which, if any, are necessary for your system.
-     See :ref:`Services_dying`.
+   * ``$ rm /root/.simp/simp_bootstrap_start_lock``
+   * ``$ simp bootstrap``
+   * ``$ puppet agent -t``
+
+   The following items are not failures and can be ignored. All other errors or warnings should be
+   addressed prior to proceeding:
+
+     * Reboot notifications.
+     * Warning/errors related to modules that manage services you have not completely set up, such as ``named``.
+     * ``svckill`` warnings regarding services found that would be killed if ``svckill::mode`` was set to ``enforcing``.
+
+       * See :ref:`Services_dying`.
 
 #. Verify user accesss
 
-  a. Verify your new user can ssh into the system.
-  b. Verify your new user can sudo to ``root`` by executing ``sudo su - root``
+   * Using a **NEW SSH SESSION OR TERMINAL** (do NOT close your working session)
+
+     * Log in as ``userx``
+     * ``sudo su - root``
 
   .. WARNING::
 
-     If your new user cannot ssh into the server and sudo to ``root``, do not
-     reboot the server until you resolve the problem!
+     If your new user cannot ssh into the server and sudo to ``root``
 
-Finalize Bootstrap Operation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     * DO NOT reboot the server until you resolve the problem!
+     * DO NOT log out of your primary work teerminal unti you resolve the problem!
 
-To finalize the bootstrap operation, reboot the server, log back in,
-wait for the ``puppetserver`` service to start and accept connections
-(can take over a minute), and then as ``root`` run ``puppet agent -t``.
+Finalization
+^^^^^^^^^^^^
 
+Reboot your system to enact the kernel-level enforcement changes:
+
+* ``$ reboot``
+
+Re-verify system access:
+
+* Log back in as ``userx``
+* ``sudo su - root``
 
 .. _Puppet module documentation: https://puppet.com/docs/puppet/latest/modules.html
-
 .. _Puppet metadata documentation: https://puppet.com/docs/puppet/latest/modules_metadata.html#metadatajson-example

--- a/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
+++ b/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
@@ -35,7 +35,7 @@ you address any other issues identified in ``/root/.simp/simp_bootstrap_start_lo
 (see :ref:`ug-other-bootstrap-lock-issues`), you can simply remove the file and
 continue with the bootstrap process.
 
-Otherwise follow the instructions in the subsections below to create a local
+Otherwise, follow the instructions in the subsections below to create a local
 user who can successfully access the system and sudo to ``root``.
 
 
@@ -167,9 +167,9 @@ This example also assumes you are logged in as ``root``.
 Resolve Other Issues in Bootstrap Lock File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The bootstrap lock file can identify other issues than user lockout.
+The bootstrap lock file can identify other issues, in addition to user lockout.
 If any other issues are identified in ``/root/.simp/simp_bootstrap_start_lock``,
-address those issues, before removing the file.
+address those issues before removing the file.
 
   * Currently, the only other issue ``simp config`` will identify is a possible
     misconfiguration of YUM repositories. ``simp config`` will lock out

--- a/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
+++ b/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
@@ -8,39 +8,39 @@ By default, SIMP:
   * Disables remote logins for all users.
   * Disables ``root`` logins at the console.
 
-If one of the following scenarios applies, you must enable ``sudo`` and ``ssh`` access for a local
-user. If you do not do this, you may lose access to your system.
+If either of the following scenarios applies, you must enable ``sudo`` and
+``ssh`` access for a local user. If you do not do this, you may lose access to
+your system.
 
-**Scenario 1:**
-
-  * Console access is available, but not allowed, for ``root`` and no other
-    user account is available.
+Scenario 1:
+  Console access is available, but not allowed.  Only the ``root`` user (and
+  no other user account) is available.
 
     * This generally occurs when SIMP is installed from RPM and the user accepts
       ``simp config``'s default value for ``useradd:securetty`` (an empty array).
 
-**Scenario 2:**
-
-  * Console access is not available and the administrative user's ``ssh``
-    access has not yet been enabled permanently via Puppet.
+Scenario 2:
+  Console access is not available, and the administrative user's ``ssh``
+  access has not yet been enabled permanently via Puppet.
 
     * This generally occurs when SIMP is installed from RPM on cloud systems.
 
-In either of these scenarios ``simp config`` will issue the following warning
-and write a lock file to prevent ``simp bootstrap`` from running.
+In either of these scenarios, ``simp config`` will issue the following warning
+and write a lock file to prevent ``simp bootstrap`` from running:
 
-::
+.. code-block:: text
 
   'simp bootstrap' has been locked due to potential login lockout.
   * See /root/.simp/simp_bootstrap_start_lock for details
 
-This remainder of this document provides instructions on creating a local user that has the
-appropriate level of system access.
+The remainder of this document provides instructions on creating a local user
+that has the appropriate level of system access.
 
 After you address all issues identified in
-``/root/.simp/simp_bootstrap_start_lock`` (see :ref:`ug-other-bootstrap-lock-issues`),
-you should remove the file and
-:ref:`continue with the bootstrap process<ug-initial_server_configuration-run_bootstrap>`.
+``/root/.simp/simp_bootstrap_start_lock`` (see
+:ref:`ug-other-bootstrap-lock-issues`), you should remove the file and
+:ref:`continue with the bootstrap
+process<ug-initial_server_configuration-run_bootstrap>`.
 
 
 Configure Local User for Access
@@ -68,14 +68,14 @@ This example creates a ``local_system_access`` :term:`Puppet module` in the
 
    .. code-block:: sh
 
-      $ umask 022
+      umask 022
 
 #. Create a ``local_system_access`` puppet module directory and change to the directory.
 
    .. code-block:: sh
 
-      $ mkdir -p /etc/puppetlabs/code/environments/production/modules/local_system_access/manifests
-      $ cd /etc/puppetlabs/code/environments/production/modules/local_system_access
+      mkdir -p /etc/puppetlabs/code/environments/production/modules/local_system_access/manifests
+      cd /etc/puppetlabs/code/environments/production/modules/local_system_access
 
 #. Add the following to a new ``manifests/local_user.pp`` file to enable ``sudo su - root``
    and allow ``ssh`` access for the user you created/selected:
@@ -129,20 +129,20 @@ This example creates a ``local_system_access`` :term:`Puppet module` in the
         ]
       }
 
-   * See the `Puppet metadata documentation`_ for more information on metadata.json files.
+   (See the `Puppet metadata documentation`_ for more information on metadata.json files.)
 
 #. Make sure the permissions are correct on the module:
 
    .. code-block:: bash
 
-      $ chown -R root:puppet $PWD
-      $ chmod -R g+rX $PWD
+      chown -R root:puppet $PWD
+      chmod -R g+rX $PWD
 
 #. Add the module to the SIMP server's host YAML file class list:
 
    .. code-block:: bash
 
-      $ cd /etc/puppetlabs/code/environments/production/data/hosts
+      cd /etc/puppetlabs/code/environments/production/data/hosts
 
    Add ``local_system_access::local_user`` to the ``simp::classes:`` array in ``<SIMP server FQDN>.yaml``
 
@@ -166,15 +166,16 @@ This example creates a ``local_system_access`` :term:`Puppet module` in the
 If Your Local User Uses an SSH Public Key
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* If the local user has an SSH public key available, copy the ``authorized_keys`` file for
-  that user to the SIMP-managed location for authorized keys ``/etc/ssh/local_keys`` as shown below:
+If the local user has an SSH public key available, copy the ``authorized_keys``
+file for that user to the SIMP-managed location for authorized keys
+``/etc/ssh/local_keys``:
 
    .. code-block:: bash
 
-      $ mkdir -p /etc/ssh/local_keys
-      $ chmod 755 /etc/ssh/local_keys
-      $ cp ~userx/.ssh/authorized_keys /etc/ssh/local_keys/userx
-      $ chmod 644 /etc/ssh/local_keys/userx
+      mkdir -p /etc/ssh/local_keys
+      chmod 755 /etc/ssh/local_keys
+      cp ~userx/.ssh/authorized_keys /etc/ssh/local_keys/userx
+      chmod 644 /etc/ssh/local_keys/userx
 
 
 .. _ug-other-bootstrap-lock-issues:
@@ -196,26 +197,30 @@ Resume Bootstrap Operation and Verify User Access
 
 .. WARNING::
 
-   **DO NOT REBOOT BEFORE VERIFYING USER ACCESS USING AN ALTERNATE TERMINAL OR SSH SESSION**
+   **DO NOT REBOOT BEFORE VERIFYING USER ACCESS USING AN ALTERNATE TERMINAL OR
+   SSH SESSION**
 
 #. Remove the lock file and bootstrap the system
 
-   * ``$ rm /root/.simp/simp_bootstrap_start_lock``
-   * ``$ simp bootstrap``
-   * ``$ puppet agent -t``
+   * ``rm /root/.simp/simp_bootstrap_start_lock``
+   * ``simp bootstrap``
+   * ``puppet agent -t``
 
-   The following items are not failures and can be ignored. All other errors or warnings should be
-   addressed prior to proceeding:
+   The following items are not failures and can be ignored. All other errors or
+   warnings should be addressed prior to proceeding:
 
      * Reboot notifications.
-     * Warning/errors related to modules that manage services you have not completely set up, such as ``named``.
-     * ``svckill`` warnings regarding services found that would be killed if ``svckill::mode`` was set to ``enforcing``.
+     * Warning/errors related to modules that manage services you have not
+       completely set up, such as ``named``.
+     * ``svckill`` warnings regarding services found that would be killed if
+       ``svckill::mode`` was set to ``enforcing``.
 
        * See :ref:`Services_dying`.
 
 #. Verify user accesss
 
-   * Using a **NEW SSH SESSION OR TERMINAL** (do NOT close your working session)
+   * Using a **NEW SSH SESSION OR TERMINAL** (do NOT close your working
+     session)
 
      * Log in as ``userx``
      * ``sudo su - root``
@@ -225,14 +230,15 @@ Resume Bootstrap Operation and Verify User Access
      If your new user cannot ssh into the server and sudo to ``root``
 
      * DO NOT reboot the server until you resolve the problem!
-     * DO NOT log out of your primary work teerminal unti you resolve the problem!
+     * DO NOT log out of your primary work terminal unti you resolve the
+       problem!
 
 Finalization
 ^^^^^^^^^^^^
 
 Reboot your system to enact the kernel-level enforcement changes:
 
-* ``$ reboot``
+* ``reboot``
 
 Re-verify system access:
 

--- a/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
+++ b/docs/user_guide/Initial_Server_Configuration/Prevent_Lockout_on_Puppetserver.inc
@@ -30,13 +30,13 @@ The warning looks like:
 
 If you have access to the console, have the ``root`` password, and have enabled
 ``root`` console access by setting ``useradd::securetty`` in :term:`Hiera` to a
-valid tty (e.g., ``tty0``), you can simply remove the file
-``/root/.simp/simp_bootstrap_start_lock`` and continue with the bootstrap
-process.
+valid tty (e.g., ``tty0``), the login lockout warning is not applicable. After
+you address any other issues identified in ``/root/.simp/simp_bootstrap_start_lock``
+(see :ref:`ug-other-bootstrap-lock-issues`), you can simply remove the file and
+continue with the bootstrap process.
 
-Otherwise follow the instructions below to enable login from a local account,
-and then remove ``/root/.simp/simp_bootstrap_start_lock`` and continue with the
-bootstrap process.
+Otherwise follow the instructions in the subsections below to create a local
+user who can successfully access the system and sudo to ``root``.
 
 
 Configure Local User for Access
@@ -45,6 +45,8 @@ Configure Local User for Access
 This example creates a manifest in a local module, ``mymodule``, in the
 ``production`` Puppet environment.  See `Puppet module documentation`_ for
 information on how to create a Puppet module.
+
+This example also assumes you are logged in as ``root``.
 
 #. Create a local user account, as needed, using ``useradd``.  This example
    assumes the local user is ``userx``.
@@ -56,31 +58,46 @@ information on how to create a Puppet module.
 #. Create a ``local_user.pp`` manifest in ``mymodule/manifests`` to enable
    ``sudo su - root`` and allow ``ssh`` access for the user you created/selected:
 
-   .. code-block:: ruby
+   a. Create the ``mymodule`` module directory and its ``manifests`` sub-directory
 
-      class mymodule::local_user (
-      Boolean $pam = simplib::lookup('simp_options::pam', { 'default_value' => false }),
-      ) {
+      .. code-block:: sh
 
-        sudo::user_specification { 'default_userx':
-          user_list => ['userx'],
-          runas     => 'root',
-          cmnd      => ['/bin/su root', '/bin/su - root']
-        }
+         $ mkdir -p /etc/puppetlabs/code/environments/production/modules/mymodule/manifests
 
-        if $pam {
-          include '::pam'
+   b. Create ``mymodule/manifests/local_user.pp`` with the following content:
 
-          pam::access::rule { 'allow_userx':
-            users   => ['userx'],
-            origins => ['ALL'],
-            comment => 'The local user, used to remotely login to the system in the case of a lockout.'
-          }
-        }
-      }
+      .. code-block:: ruby
 
-#. Create a mymodule/metadata.json file.  It should look something like the following:
-   See `Puppet metadata documentation`_ for more information on metadata.json files.
+         class mymodule::local_user (
+           Boolean $pam = simplib::lookup('simp_options::pam', { 'default_value' => false }),
+         ) {
+
+           sudo::user_specification { 'default_userx':
+             user_list => ['userx'],
+             runas     => 'root',
+          #   passwd    => false,   # only needed if user logs in without a password
+             cmnd      => ['/bin/su root', '/bin/su - root']
+           }
+
+           if $pam {
+             include 'pam'
+
+             pam::access::rule { 'allow_userx':
+               users   => ['userx'],
+               origins => ['ALL'],
+               comment => 'The local user, used to remotely login to the system in the case of a lockout.'
+             }
+           }
+         }
+
+   #. Uncomment out the ``passwd`` line in ``sudo::user_specification`` if the local
+      user is configured to login with pre-shared keys instead of a password
+      (typical cloud configuration).
+
+#. Create a ``mymodule/metadata.json`` file.
+
+   * See `Puppet metadata documentation`_ for more information on metadata.json files.
+   * It should look something like the following:
 
    .. code-block:: yaml
 
@@ -93,33 +110,33 @@ information on how to create a Puppet module.
        "source": "Your gitlab url or local",
        "dependencies": [
          {
-           "name": "simp/pam",
-           "version_requirement": ">= 6.0.0 "
+           "name": "simp/pam"
          },
          {
-           "name": "simp/sudo",
-           "version_requirement": ">= 5.1.0 "
+           "name": "simp/simplib"
          },
-
-       ],
+         {
+           "name": "simp/sudo"
+         }
+       ]
      }
 
 #. Make sure the permissions are correct on the module:
 
    .. code-block:: bash
 
-      sudo chown -R root:puppet  /etc/puppetlabs/code/environments/production/modules/mymodule
-      sudo chmod -R g+rX  /etc/puppetlabs/code/environments/production/modules/mymodule
+      $ chown -R root:puppet  /etc/puppetlabs/code/environments/production/modules/mymodule
+      $ chmod -R g+rX  /etc/puppetlabs/code/environments/production/modules/mymodule
 
 #. Add the module to the SIMP server's host YAML file class list:
 
    Edit the SIMP server's YAML file,
-   ``/etc/puppetlabs/code/environments/production/data/<SIMP server FQDN>.yaml``
-   and add the ``mymodule::local_user`` to the ``classes`` array:
+   ``/etc/puppetlabs/code/environments/production/data/hosts/<SIMP server FQDN>.yaml``
+   and add the ``mymodule::local_user`` to the ``simp::classes`` array:
 
    .. code-block:: yaml
 
-      classes:
+      simp::classes:
         - mymodule::local_user
 
 #. If the local user is configured to login with pre-shared keys instead of a
@@ -128,10 +145,10 @@ information on how to create a Puppet module.
 
    .. code-block:: bash
 
-      sudo mkdir -p /etc/ssh/local_keys
-      sudo chmod 755 /etc/ssh/local_keys
-      sudo cp ~userx/.ssh/authorized_keys /etc/ssh/local_keys/userx
-      sudo chmod 644 /etc/ssh/local_keys/userx
+      $ mkdir -p /etc/ssh/local_keys
+      $ chmod 755 /etc/ssh/local_keys
+      $ cp ~userx/.ssh/authorized_keys /etc/ssh/local_keys/userx
+      $ chmod 644 /etc/ssh/local_keys/userx
 
 
 #. Add the module to the ``Puppetfile`` in the ``production`` environment:
@@ -144,6 +161,62 @@ information on how to create a Puppet module.
 
       mod 'mymodule', :local => true
 
-.. _Puppet module documentation: https://puppet.com/docs/puppet/5.5/modules.html
+
+.. _ug-other-bootstrap-lock-issues:
+
+Resolve Other Issues in Bootstrap Lock File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The bootstrap lock file can identify other issues than user lockout.
+If any other issues are identified in ``/root/.simp/simp_bootstrap_start_lock``,
+address those issues, before removing the file.
+
+  * Currently, the only other issue ``simp config`` will identify is a possible
+    misconfiguration of YUM repositories. ``simp config`` will lock out
+    bootstrap if it cannot find a few of the key packages needed for
+    bootstrapping.  Fix your yum repository configuration and then verify the
+    fix using the verification instructions in the lock message.
+
+Resume Bootstrap Operation and Verify User Access
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. IMPORTANT::
+
+   DO NOT REBOOT BEFORE VERIFYING USER ACCESS
+
+#. Remove ``/root/.simp/simp_bootstrap_start_lock``.
+#. Run ``simp bootstrap``.
+#. Run ``puppet agent -t`` to verify that there are no warning or error
+   messages related to ``mymodule``.
+
+   * You will see a reboot notification which is expected and not an issue.
+   * You may see warning/errors related to other modules that manage
+     services you have not completely set up, such as ``named``. These are
+     expected.
+   * You may see ``svckill`` warnings about services found that would
+     be killed if ``svckill::mode`` was set to 'enforcing'. You can
+     address those later, after you have examined those services and
+     determined which, if any, are necessary for your system.
+     See :ref:`Services_dying`.
+
+#. Verify user accesss
+
+  a. Verify your new user can ssh into the system.
+  b. Verify your new user can sudo to ``root`` by executing ``sudo su - root``
+
+  .. WARNING::
+
+     If your new user cannot ssh into the server and sudo to ``root``, do not
+     reboot the server until you resolve the problem!
+
+Finalize Bootstrap Operation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To finalize the bootstrap operation, reboot the server, log back in,
+wait for the ``puppetserver`` service to start and accept connections
+(can take over a minute), and then as ``root`` run ``puppet agent -t``.
+
+
+.. _Puppet module documentation: https://puppet.com/docs/puppet/latest/modules.html
 
 .. _Puppet metadata documentation: https://puppet.com/docs/puppet/latest/modules_metadata.html#metadatajson-example

--- a/docs/user_guide/Troubleshooting/My_Services_Are_Dying.rst
+++ b/docs/user_guide/Troubleshooting/My_Services_Are_Dying.rst
@@ -12,9 +12,9 @@ Destructive Reasoning with `svckill`
 Most security guides that have been published on the Internet strongly
 suggest disabling all services that are not necessary for system
 operation. However, to list every possible service that may be
-controlled by the chkconfig type on a given system in a manifest would
-not be useful and would bloat the memory space of the running Puppet
-process.
+controlled by the ``chkconfig`` or ``systemctl`` on a given system
+in a manifest would not be useful and would bloat the memory space of
+the running Puppet process.
 
 As an alternative solution, the SIMP Team implemented the svckill
 module that runs with every Puppet run.
@@ -22,10 +22,11 @@ module that runs with every Puppet run.
 The svckill module:
 
 -  Collects a list of all services on the system. These are the same
-   services that the user sees after typing ``chkconfig --list``
+   services that the user sees after typing ``chkconfig --list`` on EL6
+   or ``systemctl list-unit-files --type=service --state=enabled`` on EL > 6.
 
--  Ignores certain critical services, including Puppet, IPtables, and
-   the network.
+-  Ignores certain critical services, including those for Puppet,
+   IPtables/firewalld, and the network.
 
 -  Collects a list of all services that are defined in the manifests and
    modules.
@@ -38,19 +39,25 @@ The svckill module:
 Avoiding Destruction
 --------------------
 
-If certain services should not be killed, declare them in the node
-manifest space or in the `svckill::ignore` array in Hiera.
+If certain services should not be killed, you have two options:
 
-.. NOTE::
+#. Add the service names to the ``svckill::ignore`` array in :term:`Hiera`.
 
-   The key is to declare the services and not set them to any other
-   option. By adding them to the manifest, the *svckill* module will
-   ignore them.
+   .. code-block::  yaml
 
-The example below demonstrates this in a manifest, assuming that the
-*keepmealive* service is added to the *chkconfig*.
+      svckill::ignore:
+      - keepmealive1
+      - keepmealive2
 
-.. code-block:: ruby
+#. Declare the services in the node manifest space:
 
-   #Preventing a service from being killed by svckill
-   service { "keepmealive": }
+  .. code-block:: ruby
+
+     # Preventing these services from being killed by svckill
+     service { "keepmealive1": }
+     service { "keepmealive2": }
+
+  .. NOTE::
+
+     The key to declaring the services in manifests is to use the
+     ``service`` resource without setting any other options.


### PR DESCRIPTION
* Fixed errors in the "Prevent Lockout from the SIMP Server..." section.
  - Path to server YAML file was missing 'hosts'.
  - ``passwd => false`` needed to be added to the ``sudo::user_specification``
    when the user does not log in with a password.
  - Example metadata.json file was malformed and missing the simplib dependency.
    Also, since versions change frequently, removed the version specifications.
  - Changed the OBE 'classes' hieradata key to 'simp::classes'.
* Added missing information to "Prevent Lockout from SIMP Server..." section.
  - Added a description of the one other lockout that is possible.
  - Added verification that the create manifest yields no errors or warnings.
  - Added verification of ssh login in sudo access before reboot.
* Added a note about required use of IP addresses in firewalld rules to
  latest changelog.
* Updated 'My Services Are Dying!' to include systemctl commands and an
  Hieradata example for svckill::ignore.
* Fixed typo in HOWTO for disabling SSH