### PR TITLE
(SIMP-8609) Add compiler warning for wrong delim

### DIFF
--- a/docs/_extensions/simp_roles.py
+++ b/docs/_extensions/simp_roles.py
@@ -47,6 +47,9 @@ def pupmod_class():
     if len(forge_names) == 2:
       url = 'https://forge.puppet.com/%s/%s' % (forge_names[0], forge_names[1])
       node = nodes.reference(rawtext, text, refuri=url, **options)
+      if re.search('-', text):
+        fixed_text = re.sub('-', '/', text)
+        print("WARNING: Use '/' to separate Puppet module names (.e.g., %s', not '%s')\n" % (fixed_text, text))
     else:
       node = nodes.inline(rawtext, text, **options)
 


### PR DESCRIPTION
The SIMP docs now prefer the forward slash delimiter to separate
Puppet modules' `org/name` references.  This patch adds a compiler
warning to the `:pupmod:` role that points out when the wrong format
is being used, and demonstrates the correct format.

[SIMP-8609] #comment :pupmod: role compiler warns on wrong delimiter

[SIMP-8609]: https://simp-project.atlassian.net/browse/SIMP-8609