### PR TITLE
(SIMP-8484) List parameters affected by firewalld limitations

### DIFF
--- a/docs/HOWTO/00_Accounts_and_Access/Configure_Ssh.rst
+++ b/docs/HOWTO/00_Accounts_and_Access/Configure_Ssh.rst
@@ -108,7 +108,7 @@ need to be noted:
      you can add them using the :code:`sshd_config_match` resource from the
      `herculesteam-augeasproviders_ssh`_ module.  Since :pupmod:`simp/ssh` uses
      this module internally, the :code:`sshd_config_match` resource will be
-     available to you on any node using :pupmod:`simp-ssh`.
+     available to you on any node using :pupmod:`simp/ssh`.
 
 
 Managing Settings for the SSH Client

--- a/docs/HOWTO/00_Accounts_and_Access/IPA_Clients.rst
+++ b/docs/HOWTO/00_Accounts_and_Access/IPA_Clients.rst
@@ -11,7 +11,7 @@ same resources that IPA provides automation for. This includes:
 +-----------------+-----------------------------------------------------+-------------------+
 | Technology      | Related SIMP Features                               | Related Tickets   |
 +-----------------+-----------------------------------------------------+-------------------+
-| :code:`sudoers` | :pupmod:`simp/simp` and :pupmod:`simp-sudo` modules | :jira:`SIMP-4898` |
+| :code:`sudoers` | :pupmod:`simp/simp` and :pupmod:`simp/sudo` modules | :jira:`SIMP-4898` |
 +-----------------+-----------------------------------------------------+-------------------+
 | :code:`autofs`  | optional :pupmod:`simp/simp_nfs` module             | :jira:`SIMP-4168` |
 +-----------------+-----------------------------------------------------+-------------------+
@@ -228,7 +228,7 @@ about user accounts that are worth noting:
 
 *  Users and groups still have to be added to PAM to be able to log in!  You
    will need to allow access using the :code:`pam::access::rule` define from the
-   :pupmod:`simp-pam` Puppet module.  For example, to allow access to the
+   :pupmod:`simp/pam` Puppet module.  For example, to allow access to the
    ``posixusers`` group created above:
 
    .. code-block:: puppet

--- a/docs/HOWTO/10_SIMP/Modify_Puppet_Cron.rst
+++ b/docs/HOWTO/10_SIMP/Modify_Puppet_Cron.rst
@@ -3,7 +3,7 @@
 Modifying the Puppet Cron Schedule
 ==================================
 
-SIMP deploys a cron-job, via :code:`pupmod::agent::cron` from the :pupmod:`simp-pupmod`
+SIMP deploys a cron-job, via :code:`pupmod::agent::cron` from the :pupmod:`simp/pupmod`
 Puppet module, to run a non-daemonized puppet agent to ensure compliance,
 over time. By default, the cron-job is run twice every hour on a semi-random
 interval, to ensure all agents do not run puppet simultaneously.  Additionally,

--- a/docs/HOWTO/20_Puppet/Block_or_Cache_Facts.rst
+++ b/docs/HOWTO/20_Puppet/Block_or_Cache_Facts.rst
@@ -3,7 +3,7 @@ Blocking or Caching Facts
 
 As described in `Configuring Facter with facter.conf`_, you can block or cache
 groups of facts on a node using settings in :file:`facter.conf` on that node.  SIMP
-has made this easier by adding management of ``facter.conf`` to :pupmod:`simp-pupmod`
+has made this easier by adding management of ``facter.conf`` to :pupmod:`simp/pupmod`
 (version >= '8.0.0'). Using this module, you can 
 managel :file:`facter.conf` and specify its configuration in :term:`Hiera`.
 

--- a/docs/HOWTO/20_Puppet/Block_or_Cache_Facts.rst
+++ b/docs/HOWTO/20_Puppet/Block_or_Cache_Facts.rst
@@ -3,7 +3,7 @@ Blocking or Caching Facts
 
 As described in `Configuring Facter with facter.conf`_, you can block or cache
 groups of facts on a node using settings in :file:`facter.conf` on that node.  SIMP
-has made this easier by adding management of ``facter.conf`` to :pupmod:`simp/pupmod`
+has made this easier by adding management of :file:`facter.conf` to :pupmod:`simp/pupmod`
 (version >= '8.0.0'). Using this module, you can 
 managel :file:`facter.conf` and specify its configuration in :term:`Hiera`.
 

--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -1681,7 +1681,7 @@ Updated the following functions:
     :code:`false`.  Previously, this function grouped the all alpha-numeric
     characters together and grouped all special characters together.  This
     generated passwords that were not suitable for user passwords, as they
-    would fail the :package`cracklib`/:package`libpwquality` complexity checks.
+    would fail the :package:`cracklib`/:package:`libpwquality` complexity checks.
 
 * :code:`simplib::assert_metadata`:
 
@@ -1812,7 +1812,7 @@ rubygem-simp-cli
     detects whether :code:`simplib::passgen` is operating in 'legacy' mode or
     'simpkv' mode in the specified environment, and then executes password
     operations using the appropriate mechanism for that mode.
-  * When setting passwords, disabled :package:`libpwquality`/:package`cracklib`
+  * When setting passwords, disabled :package:`libpwquality`/:package:`cracklib`
     validation of user-entered passwords, by default, because not all passwords
     managed by :code:`simplib::passgen` are user passwords.  This validation
     can be re-enabled with the :code:`--validate` option of

--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -300,8 +300,86 @@ ecosystem is now available.
    Be aware that :program:`firewalld` rules do not support hostnames; IP
    addresses must be used. This may impact any manifests that contain
    :code:`iptables::listen` resources, including resources from some SIMP
-   modules. You will have to change hostnames to IP addresses for the
+   modules. You will have to change any hostnames to IP addresses for the
    affected resources when using :program:`firewalld`.
+
+
+The table below is a list of the SIMP resource parameters impacted by the lack
+of hostname support by :program:`firewalld`.
+
+* Many of these parameters default to :code:`simp_options:trusted_nets`, when it
+  is available.
+* Each network element can be specified as a network (CIDR notation), an IP address,
+  'ALL' or 'any'.
+* 'or' in the table below indicates the default value that will be used if the
+  previous value is not defined.
+
++---------------------------------------------------+----------------------------------------+
+| Parameter                                         | Default Value                          |
++===================================================+========================================+
+| :code:`freeradius::v3::conf::trusted_nets`        | :code:`simp_options::trusted_nets`     |
+|                                                   | or :code:`['127.0.0.1','::1']`         |
++---------------------------------------------------+----------------------------------------+
+| :code:`krb5::kdc::firewall::trusted_nets`         | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1','::1']`        |
++---------------------------------------------------+----------------------------------------+
+| :code:`krb5::kdc::realm::trusted_nets`            | :code:`krb5::kdc::trusted_nets`        |
+|                                                   |  or :code:`simp_options::trusted_nets` |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`libreswan::trusted_nets`                   | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1/32']`           |
++---------------------------------------------------+----------------------------------------+
+| :code:`nfs::client::mount::nfs_server`            | N/A                                    |
++---------------------------------------------------+----------------------------------------+
+| :code:`nfs::server::trusted_nets`                 | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`ntpd::trusted_nets`                        | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1','::1']`        |
++---------------------------------------------------+----------------------------------------+
+| :code:`postfix::server::trusted_nets`             | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`pupmod::master::trusted_nets`              | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1','::1']`        |
++---------------------------------------------------+----------------------------------------+
+| :code:`rsync::server::trusted_nets`               | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`rsyslog::trusted_nets`                     | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1/32']`           |
++---------------------------------------------------+----------------------------------------+
+| :code:`simp::puppetdb::trusted_nets`              | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`simp_apache::ssl::trusted_nets`            | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1','::1']`        |
++---------------------------------------------------+----------------------------------------+
+| :code:`simp_apache::conf::allowroot`              | :code:`['127.0.0.1','::1']`            |
++---------------------------------------------------+----------------------------------------+
+| :code:`simp_nfs::home_dir_server`                 | N/A                                    |
++---------------------------------------------------+----------------------------------------+
+| :code:`simp_nfs::mount::home::nfs_server`         | N/A                                    |
++---------------------------------------------------+----------------------------------------+
+| :code:`simp_openldap::server::conf::trusted_nets` | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`ssh::server::conf::trusted_nets`           | :code:`['ALL']`                        |
++---------------------------------------------------+----------------------------------------+
+| :code:`stunnel::connection::trusted_nets`         | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`stunnel::instance::trusted_nets`           | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+| :code:`vsftpd::trusted_nets`                      | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1','::1']`        |
++---------------------------------------------------+----------------------------------------+
+| :code:`xinetd::service::trusted_nets`             | :code:`simp_options::trusted_nets`     |
+|                                                   |  or :code:`['127.0.0.1']`              |
++---------------------------------------------------+----------------------------------------+
+
 
 Optional Dependency Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.4.0_6.5.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.4.0_6.5.0.inc
@@ -174,9 +174,9 @@ If the :program:`mcstransd` daemon is enabled on a system, changes to how
 :file:`/proc` was mounted to allow :program:`polkit` to work can cause
 :program:`mcstransd` to send a lot of errors to the system log.
 
-:pupmod:`simp-selinux` has been updated with a fix for this, but it no longer
+:pupmod:`simp/selinux` has been updated with a fix for this, but it no longer
 manages :program:`mcstransd` by default.  To manage :program:`mcstransd` with
-the :pupmod:`simp-selinux` module, set the following in Hiera:
+the :pupmod:`simp/selinux` module, set the following in Hiera:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Updates:
* List SIMP resource parameters that cannot contain hostnames when
  firewalld is enabled.
* Remove :pupmod: errors used to demonstrate that role's validation
  logic.

SIMP-8484 #close