### PR TITLE
(SIMP-MAINT) Switch csv-filter to :include:

### DIFF
--- a/docs/contributors_guide/Documentation.rst
+++ b/docs/contributors_guide/Documentation.rst
@@ -27,7 +27,7 @@ formatting such as bold ``*text*`` or double-backticks (``````):
      :file: documentation_custom_roles.csv
      :delim: |
      :included_cols: 0,1,2,3
-     :exclude: {4: '(?i)^(simp-only|inline)$'}
+     :include: {4: '(?i)^built-in$'}
 
 .. csv-filter:: Custom roles, created for simp-doc
      :header-rows: 1
@@ -35,7 +35,7 @@ formatting such as bold ``*text*`` or double-backticks (``````):
      :file: documentation_custom_roles.csv
      :delim: |
      :included_cols: 0,1,2,3
-     :exclude: {4: '(?i)^(built-in|inline)$'}
+     :include: {4: '(?i)^simp-only$'}
 
 .. csv-filter:: Inline formatting
      :header-rows: 1
@@ -43,7 +43,7 @@ formatting such as bold ``*text*`` or double-backticks (``````):
      :file: documentation_custom_roles.csv
      :delim: |
      :included_cols: 0,1,2,3
-     :exclude: {4: '(?i)^(simp-only|built-in)$'}
+     :include: {4: '(?i)^inline$'}
 
 SIMP Puppet modules
 """""""""""""""""""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx>=1.7.9,<1.8.0
 PyYAML
 rst2pdf
-sphinx-csv-filter
+sphinx-csv-filter>=0.3.0


### PR DESCRIPTION
This patch updates `requirements.txt` to use sphinx-csv-filter 0.3.0+
and converts the `csv-filter` directives in the Contributors' style
guide to use the (much clearer) `:include:` filter.