### PR TITLE
(SIMP-8616) Firewall doc updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Nov 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com>
+- Updated firewall-related docs in the changelog
+- Added a HOWTO for fully disabling a system's firewall
+
 * Tue Oct 06 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com>
 - Added upgrade instructions for 6.4.0 to 6.5.0
 

--- a/docs/HOWTO/10_SIMP/Disable_the_Firewall.rst
+++ b/docs/HOWTO/10_SIMP/Disable_the_Firewall.rst
@@ -17,6 +17,7 @@ following via :term:`Hiera`:
 
    iptables::enable: false
    firewalld::service_enable: false
+   firewalld::service_ensure: 'stopped'
 
 As per usual, once this is set, Puppet will ensure that the firewall is fully disabled until the
 settings are reversed.

--- a/docs/HOWTO/10_SIMP/Disable_the_Firewall.rst
+++ b/docs/HOWTO/10_SIMP/Disable_the_Firewall.rst
@@ -1,0 +1,27 @@
+.. _howto-disable-the-firewall:
+
+Fully Disabling the System Firewall
+===================================
+
+Though we hope that you never actually want to do this, there may be situations where you want to
+use puppet to fully disable the system firewall.
+
+When :program:`iptables` was the only option, this was very straightforward. The introduction of
+:program:`firewalld` has added a bit of complexity due to the preservation of backwards
+compatibility with calls into the :code:`iptables::rules::*` :term:`defined types`.
+
+To fully disable **all** firewalls on the system (not just management of the firewalls) set the
+following via :term:`Hiera`:
+
+.. code-block:: yaml
+
+   iptables::enable: false
+   firewalld::service_enable: false
+
+As per usual, once this is set, Puppet will ensure that the firewall is fully disabled until the
+settings are reversed.
+
+.. IMPORTANT::
+
+   Just setting :code:`firewalld::service_enable: false` will likely cause your system to fall back
+   to using :program:`iptables`.

--- a/docs/changelogs/latest.rst
+++ b/docs/changelogs/latest.rst
@@ -298,8 +298,8 @@ SIMP-6.5.0 ISOs deliver Puppet 6 application RPMs.
 firewalld Support
 ^^^^^^^^^^^^^^^^^
 
-As of SIMP 6.5.0, preliminary :program:`firewalld` support within the SIMP
-ecosystem is now available.
+As of SIMP 6.5.0, :program:`firewalld` support is available within the SIMP and is the default for
+all new installations on platforms that support it.
 
 * **New simp/simp_firewalld module**: SIMP now includes
   :pupmod:`simp/simp_firewalld` which provides a profile class and defined type


### PR DESCRIPTION
Changed:
  - Updated the changelog docs to note that firewalld is now the default
    for new installations

Added:
  - Added a HOWTO for fully disabling the system firewall

SIMP-8616 #comment related doc updates