### PR TITLE
(SIMP-9121) Bump ruby version to 2.5.7

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,42 +200,52 @@ linkcheck_anchors = False
 # A regex of links that the linkcheck builder should ignore
 linkcheck_ignore = [
     # ignore rpms
-    r'^http[s]?:\/\/.*\.(src\.)?rpm$',
+    r'^https?:\/\/.*\.(src\.)?rpm$',
     # ignore pdfs
-    r'^http[s]?:\/\/.*\.pdf$',
+    r'^https?:\/\/.*\.pdf$',
     # ignore doc
-    r'^http[s]?:\/\/.*\.doc(x)?$',
+    r'^https?:\/\/.*\.doc(x)?$',
     # ignore isos
-    r'^http[s]?:\/\/.*\.iso$',
+    r'^https?:\/\/.*\.iso$',
     # ignore tarballs
-    r'^http[s]?:\/\/.*\.tar(\..{2,3})?$',
+    r'^https?:\/\/.*\.tar(\..{2,3})?$',
     # links that the resolver has trouble with
-    r'^http[s]?:\/\/groups\.google\.com\/forum\/.+',
-    r'^http[s]?:\/\/travis-ci\.org(/.*|$)',
-    r'^http[s]?:\/\/bundler\.io/rationale\.html',
+    r'^https?:\/\/groups\.google\.com\/forum\/.+',
+    r'^https?:\/\/travis-ci\.org(/.*|$)',
+    r'^https?:\/\/bundler\.io/rationale\.html',
     # Puppet redirects everything everywhere
-    r'^http[s]?:\/\/.*\.puppet.com(/.*|$)',
+    r'^https?:\/\/.*\.puppet\.com(/.*|$)',
     # NIST redirects everything everywhere
-    r'^http[s]?:\/\/.*\.nist.gov(/.*|$)',
+    r'^https?:\/\/.*\.nist.gov(/.*|$)',
     # Microsoft redirects everything everywhere
-    r'^http[s]?:\/\/.*\.microsoft.com(/.*|$)',
+    r'^https?:\/\/.*\.microsoft\.com(/.*|$)',
     # SSL errors
-    r'^http[s]?:\/\/www\.elastic\.co(/.*|$)',
-    r'^http[s]?:\/\/opensource\.org(/.*|$)',
+    r'^https?:\/\/www\.elastic\.co(/.*|$)',
+    r'^https?:\/\/opensource\.org(/.*|$)',
     # Everything from pgp.mit.edu
-    r'^http[s]?:\/\/pgp\.mit\.edu(/.*|$)',
+    r'^https?:\/\/pgp\.mit\.edu(/.*|$)',
     # These are for the templates in the release emails
     r'.*VERSION.*Upgrade_SIMP.*',
     r'.*VERSION-.*NUM.*Changelog\.html',
     # Ignore github searches since they'll cause the API to timeout
-    r'^http[s]:\/\/github\.com\/search\?.*',
+    r'^https?:\/\/github\.com\/search\?.*',
     # FIXME: Puppet is redirecting permanently instead of temporarily which
     # they need to fix
-    r'^http[s]:\/\/puppet.com\/docs\/.+\/latest\/.+',
+    r'^https?:\/\/puppet\.com\/docs\/.+\/latest\/.+',
     # FIXME: This site is currently dead
-    r'^http[s]:\/\/www.open-scap.org.*',
+    r'^https?:\/\/www.open-scap.org.*',
     # Qualys randomly fails
-    r'^http[s]:\/\/.*.qualys.com.*'
+    r'^https?:\/\/.*.qualys\.com.*',
+    #
+    # https://wiki.x2go.org/doku.php started failing link checks because it
+    # used a newly-minted CA + cert as of 2020/12/10.  As of this comment,
+    # the latest python `certifi` release (v 2020.12.05) doesn't support the
+    # new CA.
+    #
+    # FIXME: Periodically retest with newer versions of `certifi`:
+    #    See: https://github.com/certifi/python-certifi/releases
+    #
+    r'^https?://wiki\.x2go\.org/?.*'
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/getting_started_guide/Installation_Options/ISO/ISO_Build/Environment_Preparation.rst
+++ b/docs/getting_started_guide/Installation_Options/ISO/ISO_Build/Environment_Preparation.rst
@@ -44,23 +44,23 @@ install :term:`RVM` for your user.
    gpg2 --keyserver hkp://keys.gnupg.net --recv-keys \
        409B6B1796C275462A1703113804BB82D39DC0E3 \
        7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-   \curl -sSL https://get.rvm.io | bash -s stable --ruby=2.4.4
+   \curl -sSL https://get.rvm.io | bash -s stable --ruby=2.5.7
    source ~/.rvm/scripts/rvm
 
 
 Set the Default Ruby
 ^^^^^^^^^^^^^^^^^^^^
 
-You will want to use :term:`Ruby` ``2.4.4`` as your default :term:`RVM` for SIMP
+You will want to use :term:`Ruby` ``2.5.7`` as your default :term:`RVM` for SIMP
 development.
 
 .. code-block:: bash
 
-   rvm use --default 2.4.4
+   rvm use --default 2.5.7
 
 .. NOTE::
 
-   Once this is done, you can simply type ``rvm use 2.4.4``.
+   Once this is done, you can simply type ``rvm use 2.5.7``.
 
 
 


### PR DESCRIPTION
This patch brings the environment prep docs' Ruby version in line with
Puppet 6

[SIMP-9121] #close

[SIMP-9121]: https://simp-project.atlassian.net/browse/SIMP-9121