### PR TITLE
(SIMP-10203) Fix SSL recovery documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Wed Jul 14 2021 Trevor Vaughan <tvaughan@onyxpoint.com>
+- Correct SSL recovery documentation
+- Convert all instances of 'puppet master' to 'puppet server'
+- Correct a few links
+
 * Wed Jun 30 2021 Trevor Vaughan <tvaughan@onyxpoint.com>
 - Add 389-DS documentation
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You may need some additional OS packages for building PDFs with sphinx
 Install python dependencies:
 
 ```sh
+virtualenv venv
+source venv/bin/activate
+
+pip install --upgrade pip setuptools
 pip install -r requirements.txt
 ```
 

--- a/docs/FAQ/Puppet.rst
+++ b/docs/FAQ/Puppet.rst
@@ -27,7 +27,7 @@ troubleshoot the issue.
    .. code-block:: bash
 
       openssl s_client -host $(puppet config print server) \
-      -port $(puppet config print masterport) \
+      -port $(puppet config print serverport) \
       -cert $(puppet config print hostcert) \
       -key $(puppet config print hostprivkey) \
       -CAfile $(puppet config print localcacert)

--- a/docs/HOWTO/20_Puppet/Changing_Puppet_Masters.rst
+++ b/docs/HOWTO/20_Puppet/Changing_Puppet_Masters.rst
@@ -3,7 +3,7 @@
 HOWTO Move a Client to a new Puppet Server
 ==========================================
 
-The following provides details on how to move an client to a new Puppet server.
+The following provides details on how to move an client to a new :term:`Puppet Server`.
 
 .. NOTE::
 
@@ -13,7 +13,7 @@ On the Old Puppet Server
 ------------------------
 
 The following procedures will archive the agent's artifacts from all environments, copy them to the new
-Puppet server, and clean out the agent's Hiera data.
+Puppet Server, and clean out the agent's :term:`Hiera` data.
 
 Archive the agent's artifacts from all environments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ Archive the agent's artifacts from all environments
 
   .. code-block:: shell
 
-     find `puppet config --section master print vardir`/simp -name "*<agent-fqdn>*" -exec tar --selinux --xattrs -rpvf <agent-fqdn>_transfer.tar {} \;
+     find `puppet config --section server print vardir`/simp -name "*<agent-fqdn>*" -exec tar --selinux --xattrs -rpvf <agent-fqdn>_transfer.tar {} \;
 
 
 3. Archive the agent's Hiera data from all :term:`Puppet Environments`:
@@ -73,7 +73,7 @@ Remove agent-specific Hiera data from all environments
 
      puppetserver reload
 
-On the New Puppet Master
+On the New Puppet Server
 ------------------------
 
 .. WARNING::

--- a/docs/HOWTO/20_Puppet/Disconnect_PuppetDB_from_Puppet_Server.rst
+++ b/docs/HOWTO/20_Puppet/Disconnect_PuppetDB_from_Puppet_Server.rst
@@ -18,7 +18,7 @@ restart the :program:`puppetserver` process without the connection.
    # /etc/puppetlabs/puppet (the default).
    mv /etc/puppetlabs/puppet/routes.yaml /etc/puppetlabs/puppet/routes.yaml.backup
 
-   puppet config set --section master storeconfigs false
+   puppet config set --section server storeconfigs false
    puppet config set --section main storeconfigs false
 
    puppet resource service puppetserver ensure=stopped

--- a/docs/HOWTO/20_Puppet/ENC_setup.rst
+++ b/docs/HOWTO/20_Puppet/ENC_setup.rst
@@ -21,7 +21,7 @@ To use this script for your ENC, do the following as ``root``:
 
 #. Configure Puppet to use this script as an ENC
 
-   Set the following in the :code:`[master]` section of :file:`/etc/puppetlabs/puppet/puppet.conf`:
+   Set the following in the :code:`[server]` section of :file:`/etc/puppetlabs/puppet/puppet.conf`:
 
    a. Add or change the line :code:`node_terminus` to :code:`exec`.
    b. Set the :code:`external_nodes` entry to :file:`/usr/local/bin/set_environment`.
@@ -31,7 +31,7 @@ To use this script for your ENC, do the following as ``root``:
    .. code-block:: ini
 
       ...
-      [master]
+      [server]
       ...
       node_terminus = exec
       external_nodes = /usr/local/bin/set_environment
@@ -51,7 +51,7 @@ To use this script for your ENC, do the following as ``root``:
 
    .. code-block:: yaml
 
-      # The puppetmaster will use the production environment
+      # The puppet server will use the production environment
       'puppet.my.domain':            'production'
 
       # Any node in my.domain whose FQDN begins with test will use the test environment

--- a/docs/HOWTO/20_Puppet/Puppetmaster_Backup.rst
+++ b/docs/HOWTO/20_Puppet/Puppetmaster_Backup.rst
@@ -3,18 +3,18 @@
 HOWTO Back up the Puppet Server
 ===============================
 
-This section details the steps required to back up the Puppet master.
+This section details the steps required to back up the :term:`Puppet Server`.
 
 .. NOTE::
 
-   A default SIMP installation can use Git as a rudimentary method to back up
-   the Puppet server. If a different method is preferred, the user must install
-   and configure it first.
+   A default SIMP installation can use :term:`Git` as a rudimentary method to
+   back up the Puppet Server. If a different method is preferred, the user must
+   install and configure it first.
 
 #. Backup :file:`/etc/puppetlabs/puppet/ssl`
 #. Backup :file:`/etc/puppetlabs/puppet`
 #. Backup :file:`/var/simp`
-#. Backup :file:`\`puppet config --section master print vardir\`/simp`
+#. Backup :file:`\`puppet config --section server print vardir\`/simp`
 #. *Optional:* Backup :file:`/var/www`
 
 
@@ -22,7 +22,7 @@ This section details the steps required to back up the Puppet master.
 
 .. code-block:: bash
 
-   # tar --selinux --xattrs -czpvf simp_backup-$(date +%Y-%m-%d).tar.gz /etc/puppetlabs /var/simp `puppet config --section master print vardir`/simp /var/www /var/simp
+   # tar --selinux --xattrs -czpvf simp_backup-$(date +%Y-%m-%d).tar.gz /etc/puppetlabs /var/simp `puppet config --section server print vardir`/simp /var/www /var/simp
 
 **Simple Full Restore Command**
 
@@ -34,4 +34,4 @@ This section details the steps required to back up the Puppet master.
 .. NOTE::
 
    This only backs up data that is managed/owned by Puppet. It will not backup any
-   application-centric data (such as the contents of LDAP).
+   application-centric data (such as the contents of :term:`LDAP`).

--- a/docs/HOWTO/90_Misc/Kerberos.rst
+++ b/docs/HOWTO/90_Misc/Kerberos.rst
@@ -107,7 +107,7 @@ Propagate the Keytabs
 
 Move all of the resulting keytab files SECURELY to
 ``/var/simp/environments/<client_environment>/site_files/krb5_files/keytabs/<fqdn>``
-on the Puppet master as appropriate for each file.
+on the :term:`Puppet Server` as appropriate for each file.
 
 .. NOTE::
 

--- a/docs/HOWTO/90_Misc/SNMPD.rst
+++ b/docs/HOWTO/90_Misc/SNMPD.rst
@@ -2,7 +2,7 @@ HOWTO Configure SNMPD
 =====================
 
 This document details how to use the ``simp-simp_snmpd`` Puppet profile module
-to configure the SNMP daemon.
+to configure the :term:`SNMP` daemon.
 
 Simple instructions to configure the snmpd daemon using the
 ``simp-simp_snmpd`` profile module are described in its README file.
@@ -87,7 +87,7 @@ The profile module, by default, installs two users:
 * ``snmp_rw`` is configured for read/write access to everything
 
 User passwords are auto-generated using ``simplib::passgen()`` and stored on
-the Puppet master in a sub-directory in the :term:`SIMP Writable Environment`:
+the :term:`SIMP Server` in a sub-directory in the :term:`SIMP Writable Environment`:
 
 ``/opt/puppetlabs/server/data/puppetserver/simp/environments/production/simp_autofile/gen_passwd``.
 
@@ -95,8 +95,8 @@ Access is configured by ``/etc/snmp/simp_snmpd.d/access.conf``
 
 * To create the ``access.conf`` file, the profile modules uses a set of hashes.
 * The default hashes are in the ``data/common.yaml`` file.
-* These hashes are merged with any hash you defined in the Hiera files on the
-  Puppet master.  Merging is described in
+* These hashes are merged with any hash you defined in the :term:`Hiera` files on the
+  :term:`Puppet Server`. Merging is described in
   `Puppet docs <https://puppet.com/docs/puppet/5.5/hiera_merging.html>`_
 * To remove something from the default hash add the name of object with no keys
 

--- a/docs/changelogs/6.5.0_Changelog.rst
+++ b/docs/changelogs/6.5.0_Changelog.rst
@@ -2308,6 +2308,5 @@ the following:
 
 
 .. _submit an issue: https://simp-project.atlassian.net
-.. _simp-project.com: https://simp-project.com
+.. _simp-project.com: https://www.simp-project.com
 .. _packagecloud: https://packagecloud.io/simp-project
-

--- a/docs/contributors_guide/Testing_on_FIPS_Systems.rst
+++ b/docs/contributors_guide/Testing_on_FIPS_Systems.rst
@@ -56,7 +56,7 @@ section:
    end
 
 .. _Bundler: https://bundler.io/
-.. _fix: https://github.com/rubygems/bundler/issues/5440
-.. _new bug: https://github.com/rubygems/bundler/issues/5584
+.. _fix: https://github.com/rubygems/bundler/pull/5440
+.. _new bug: https://github.com/rubygems/bundler/pull/5584
 .. _original bug: https://github.com/rubygems/bundler/issues/4989
 .. _some issues: https://github.com/rubygems/bundler/issues/4989#issuecomment-280503064

--- a/docs/contributors_guide/documentation_custom_roles.csv
+++ b/docs/contributors_guide/documentation_custom_roles.csv
@@ -10,4 +10,4 @@ Jira issues|:jira:`SIMP-8464`|``:jira:`SIMP-8464```| Auto-links to (SIMP project
 Literal text|``keyword``|````keyword````|ReST's basic markup for fixed-width text.  Only use this if there isn't an appropriate role.|inline
 Internal hyperlinks| :ref:`changelogs` | ``:ref:`changelogs```| ``:ref:`` crosslinks are actually built-in roles, but we'll group them here |inline
 Glossary terms|:term:`SIMP`|``:term:`SIMP```|Automatically creates internal hyperlink to term in Glossary|built-in
-External hyperlinks| `SIMP website <https://simp-project.com>`_ |```SIMP website <https://simp-project.com>`_``| External hyperlinks are decorated with a special icon|inline
+External hyperlinks| `SIMP website <https://www.simp-project.com>`_ |```SIMP website <https://www.simp-project.com>`_``| External hyperlinks are decorated with a special icon|inline

--- a/docs/contributors_guide/maintenance/other_iso_related_project_release_procedures/Pre_Release_Checklist.rst
+++ b/docs/contributors_guide/maintenance/other_iso_related_project_release_procedures/Pre_Release_Checklist.rst
@@ -174,7 +174,7 @@ do the following:
       If the component requires updated dependencies, those RPMs will
       have to be built and installed at the same time.
 
-#. Verify the ``puppet agent`` runs succeed on the Puppet master
+#. Verify the ``puppet agent`` runs succeed on the :term:`Puppet Server`
 
    * login as root
    * execute ``puppet agent -t``

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -150,7 +150,7 @@ Glossary of Terms
    Code Manager
       [Puppet] Code Manager automates the management and deployment of
       your :term:`Puppet` code. Push code updates to your source control repo,
-      and then Puppet syncs the code to your masters, so that all your servers
+      and then Puppet syncs the code to your servers, so that all your servers
       start running the new code at the same time, without interrupting agent
       runs.
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -87,6 +87,12 @@ Glossary of Terms
    Certificate Authority
       An entity that issues :term:`X.509` digital certificates.
 
+   CRL
+   Certificate Revocation List
+      A list of digitical certificates that have been revoked by the :term:`CA`.
+
+      Source: `Wikipedia: Certificate revocation list <https://en.wikipedia.org/wiki/Certificate_revocation_list>`__
+
    Class
    Classes
    Puppet Class
@@ -729,17 +735,12 @@ Glossary of Terms
    Puppetfile
       A Ruby file that contains references to :term:`Puppet modules`.
 
-      See the Puppetfile spec: https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd
+      See the Puppetfile spec: https://github.com/puppetlabs/r10k/blob/main/doc/puppetfile.mkd
 
    PuppetForge
       An official repository for Puppet modules
 
       See: https://forge.puppet.com/
-
-   Puppet Master
-      For the purposes of this document, this is the Server upon which the
-      :term:`puppetserver` process is running and to which your clients
-      connect.
 
    Puppet Module
    Puppet Modules
@@ -761,11 +762,9 @@ Glossary of Terms
 
    Puppetserver
    Puppet Server
-      An application that runs on the Java Virtual Machine (JVM) and provides
-      the same services as the classic Puppet master application. It mostly
-      does this by running the existing Puppet master code in several JRuby
-      interpreters, but it replaces some parts of the classic application with
-      new services written in Clojure.
+      An application that runs on the Java Virtual Machine (JVM) and provides a
+      puppet compiler service by running several JRuby interpreters running the
+      Puppet compiler through a Clojure-based service.
 
       Source: `Puppet's Services: Puppet Server <https://puppet.com/docs/puppetserver/latest/services_master_puppetserver.html>`__
 
@@ -953,7 +952,7 @@ Glossary of Terms
       The first server that is built in a SIMP environment and the server that
       is expected to be the nexus of control for the managed infrastructure.
 
-      See: :term:`Puppet Master`
+      See: :term:`Puppet Server`
 
    SIMP Writable Environment
    Writable Environment
@@ -997,6 +996,13 @@ Glossary of Terms
          $env=`puppet config print environment`
 
          echo "${env_path}/${env}/modules/site"
+
+   SNMP
+   Simple Network Management Protocol
+      A protocl for collecting and organizing information about managed devices
+      on IP networks.
+
+      Source: `Wikipedia: Simple Network Management Protocol <https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol>`__
 
    Spectre
       A vulnerability that affects modern microprocessors that perform branch

--- a/docs/security_conop/Operational_Security.rst
+++ b/docs/security_conop/Operational_Security.rst
@@ -15,9 +15,9 @@ Baseline Configurations
 SIMP baselines include configuration settings and Puppet modules.  Currently,
 baselines are maintained for both Red Hat/CentOS 6.x, and Red Hat/CentOS 7.x.
 Each configuration item that is managed by a Puppet module has an RPM installed
-on the Puppet Master in the form of ``pupmod-name-x.x.x-x``. This process
+on the :term:`Puppet Server` in the form of ``pupmod-name-x.x.x-x``. This process
 allows for one main SIMP baseline to be maintained and modules to be upgraded
-easily. An overall SIMP RPM is also installed on the Puppet Master, which
+easily. An overall SIMP RPM is also installed on the Puppet Server, which
 denotes the version number of SIMP that is installed.
 [:ref:`CM-2`, :ref:`CM-2 (2)`, :ref:`CM-2 (3)`, :ref:`CM-6`]
 
@@ -103,8 +103,8 @@ any file managed by Puppet). In the event that a managed file is changed
 locally, Puppet will revert the file back to its original state.  It is
 important to note that this is a function of Puppet and is intended to be more
 of a configuration management feature rather than a security feature. If a
-Puppet client has been compromised, the Puppet Master may not have the ability
-to retake control over that client.  However, the Puppet Master can configure
+Puppet client has been compromised, the Puppet Server may not have the ability
+to retake control over that client.  However, the Puppet Server can configure
 all other nodes to deny traffic from the compromised node if they are
 configured by the administrator to do so. There are additional configuration
 files that are checked by AIDE, which is triggered by a cron job. AIDE logs any

--- a/docs/security_conop/System_Management.rst
+++ b/docs/security_conop/System_Management.rst
@@ -24,12 +24,12 @@ describes the known areas in SIMP.
   - * Risk
     * Possible Mitigations
   - * **Disabling Puppet**: This can cause the clients to be out of sync with
-      the Puppet Master.
+      the :term:`Puppet Server`.
     * SIMP attempts to force a break on any locks and restart Puppet on all
       clients after a time of 4*runinterval (30 minutes by default).
       Implementations should ensure that further steps have not been taken to
       disable Puppet and should monitor their logs. Administrators can use the
-      puppetlast command on the Puppet Master to detect servers that have not
+      puppetlast command on the Puppet Server to detect servers that have not
       checked in within a reasonable time period.
   - * **Out of Date Patches**: SIMP can be built with the RPMs from CentOS or
       Red Hat. Those RPMs should be assumed out of date at the time a system is

--- a/docs/security_conop/Technical_Security.rst
+++ b/docs/security_conop/Technical_Security.rst
@@ -186,7 +186,7 @@ Default Server Ports
 =========== ========= ========== ========= ======= =======================================================================
 Application Direction Protocol   Transport Ports   Comment
 =========== ========= ========== ========= ======= =======================================================================
-Puppet      Localhost HTTP       TCP       8140    The port upon which the Puppet master listens for client connections via Apache
+Puppet      Localhost HTTP       TCP       8140    The port upon which the :term:`Puppet Server` listens for client connections via Apache
 Puppet CA   In        HTTPS      TCP       8141    This is used to ensure that Apache can verify all certificates from external systems properly prior to allowing access to Puppet.
 Apache/YUM  In        HTTP       TCP       443     This is used for YUM and is encrypted using https.
 DHCPD       In        DHCP/BOOTP TCP/UDP   546,547 DHCP pooling is disabled by default and should only be used if the implementation requires the use of this protocol.
@@ -509,9 +509,9 @@ the log server over a TLS protected link.
 Time Synchronization
 --------------------
 
-Each SIMP client (including the Puppet Master) has ``ntpd`` enabled by default.
+Each SIMP client (including the Puppet Server) has ``ntpd`` enabled by default.
 Part of the installation directs the clients to a time server.  If no servers
-are available, the SIMP clients can use the Puppet Master as the central time
+are available, the SIMP clients can use the Puppet Server as the central time
 source. Audit logs receive their time stamp from the local server's system
 clock; therefore, the SIMP client must be connected to a central time source
 for timestamps in audit logs to be accurate.

--- a/docs/security_mapping/components/apache/automated_central_management_application_verification/control.rst
+++ b/docs/security_mapping/components/apache/automated_central_management_application_verification/control.rst
@@ -1,8 +1,8 @@
 Automated Central Management / Application / Verification
 ---------------------------------------------------------
 
-SIMP uses rsync (over stunnel) to keep files in ``/var/www`` synchronized between
+SIMP uses `rsync` (over `stunnel`) to keep files in ``/var/www`` synchronized between
 all web servers.  Any files that need to be the same on all web servers are
-then managed from the puppet master.
+then managed from the :term:`Puppet Server`.
 
 References: :ref:`CM-7 (1)`

--- a/docs/security_mapping/components/apache/transmission_confidentiality_and_integrity/control.rst
+++ b/docs/security_mapping/components/apache/transmission_confidentiality_and_integrity/control.rst
@@ -1,9 +1,9 @@
 Transmission Confidentiality and Integrity
 ------------------------------------------
 
-The SIMP server/puppet master has an SSL enabled Apache web server running on
-port 443.  The protocols are limited to TLSv1, TLSv1.1, and TLSv1.2.  If the
-web client does not support those protocols, the connection will be rejected.
-The certificates are in the ``/etc/pki/simp_apps/simp_apache/x509`` directory.
+The :term:`SIMP Server` has a :term:`TLS` enabled Apache web server running on
+port 443.  The protocols are limited to TLSv1.2.  If the web client does not
+support those protocols, the connection will be rejected.  The certificates are
+in the ``/etc/pki/simp_apps/simp_apache/x509`` directory.
 
 References: :ref:`SC-8`

--- a/docs/security_mapping/components/named/automated_central_management_application_verification/control.rst
+++ b/docs/security_mapping/components/named/automated_central_management_application_verification/control.rst
@@ -1,7 +1,7 @@
 Automated Central Management / Application / Verification
 ---------------------------------------------------------
 
-Named configuration files are synchronized between the puppet master and the
-named servers using rsync.
+`Named` configuration files are synchronized between the :term:`Puppet Server`
+and the :term:`DNS` servers using `rsync`.
 
 References: :ref:`CM-7 (1)`

--- a/docs/security_mapping/components/pam/least_privilege/control.rst
+++ b/docs/security_mapping/components/pam/least_privilege/control.rst
@@ -5,7 +5,7 @@ SIMP uses the access conf file to identify which accounts can login to a system.
 After all other identification and authentication checks have passed, the pam
 access.conf file is checked to ensure the user is allowed to login.  SIMP
 allows ``root`` and the ``administrators`` group to login to all systems and the
-``simp`` user to login to the puppet master.  All other users must be explicitly
-added to the access.conf file using the SIMP pam module.
+``simp`` user to login to the :term:`Puppet Server`. All other users must be
+explicitly added to the ``access.conf`` file using the SIMP `pam` module.
 
 References: :ref:`AC-6`

--- a/docs/security_mapping/components/pupmod/access_enforcement/control.rst
+++ b/docs/security_mapping/components/pupmod/access_enforcement/control.rst
@@ -1,9 +1,9 @@
 Access Enforcement
 ------------------
 
-The puppet master uses a whitelist to determine which puppet clients can connect
-to the puppet master.  The certificate of the connecting client must match the
-fully qualified domain name of the system.  If it doesn't, then the connection
-is denied.
+The :term:`Puppet Server` uses a whitelist to determine which puppet clients can
+connect via the network.  The certificate of the connecting client must match
+the fully qualified domain name of the system as resolved via :term:`DNS`.  If
+it does not then the connection is denied.
 
 References: :ref:`AC-3`

--- a/docs/security_mapping/components/pupmod/audit_storage_capacity/control.rst
+++ b/docs/security_mapping/components/pupmod/audit_storage_capacity/control.rst
@@ -5,8 +5,8 @@ The Puppet logs are written to the ``/var/log`` partition.  This puts them on
 the same logical volume as the audit logs.  That volume is mounted on a separate
 partition so that log space does not interfere with operations.
 
-The puppet master logs reports from client puppet runs in
-``/var/lib/puppet/reports``.  The SIMP pupmod puppet module purges reports older
-than 7 days.
+The :term:`Puppet Server` logs reports from client puppet runs in
+``/var/lib/puppet/reports``.  The SIMP `pupmod` :term:`puppet module` purges
+reports older than 7 days.
 
 References: :ref:`AU-4`

--- a/docs/security_mapping/components/pupmod/automated_change_implementation/control.rst
+++ b/docs/security_mapping/components/pupmod/automated_change_implementation/control.rst
@@ -3,19 +3,19 @@ Automated Change Implementation
 
 The most prominent tool in the SIMP architecture is Puppet.  Puppet is a
 client/server tool where managed nodes run the Puppet agent application.
-One or more servers run the Puppet master application in the form of
-Puppet Server.
+One or more servers run the :term:`Puppet Server` application in the form of
+a web-based service using :term:`TLS` encrypted connections.
 
-The  Puppet agent sends facts to the Puppet master and request a
-catalog. The master compiles and returns that node’s catalog, using several
+The  Puppet agent sends facts to the Puppet Server and request a
+catalog. The master compiles and returns that node's catalog, using several
 sources of information it has access to.
 
 Once it receives a catalog, Puppet agent applies it by checking each resource
 the catalog describes. If it finds any resources that are not in their desired
 state, it makes any changes necessary to correct them. After applying the
-catalog, the agent submits a report to the Puppet master.
+catalog, the agent submits a report to the Puppet Server.
 
-Puppet clients have a cron job configured to run the puppet agent every 30
-minutes.
+Puppet clients have a scheduled job configured to run the puppet agent every 30
+minutes by default.
 
 References: :ref:`CM-3 (3)`

--- a/docs/security_mapping/components/pupmod/content_of_audit_records/control.rst
+++ b/docs/security_mapping/components/pupmod/content_of_audit_records/control.rst
@@ -1,7 +1,8 @@
 Content of Audit Records
 ------------------------
 
-The puppet master's log level is set to ``WARN``. Any changes that are made
-during a run of the puppet agent, are logged to the client's log file.
+The :term:`Puppet Server` log level is set to ``WARN``. Any changes that are made
+during a run of the puppet agent, are logged to the client's log file and
+captured by :term:`syslog`.
 
 References: :ref:`AU-3`

--- a/docs/security_mapping/components/pupmod/information_flow_enforcement/control.rst
+++ b/docs/security_mapping/components/pupmod/information_flow_enforcement/control.rst
@@ -1,9 +1,11 @@
 Information Flow Enforcement
 ----------------------------
 
-The pupmod module explicitly opens up ports 8140 and 8141
-using IPTables rules.  Port 8140 is the puppet master port and 8141 is the
-certificate authority port.  The connecting source IPs are limited to the value of
-``$trusted_nets``, which for most installs is the local network.
+The `pupmod` :term:`puppet module` listens on ports 8140 and 8141 by default and
+makes these ports available via the system firewall.
+
+Port 8140 is the :term:`Puppet Server` port and 8141 is the certificate
+authority port.  The connecting source IPs are limited to the value of
+``$trusted_nets``, which for most installs, is the local network.
 
 References: :ref:`AC-4`

--- a/docs/security_mapping/components/pupmod/public_key_infrastructure_certificates/control.rst
+++ b/docs/security_mapping/components/pupmod/public_key_infrastructure_certificates/control.rst
@@ -1,15 +1,15 @@
 Public Key Infrastructure
 -------------------------
 
-Puppet has its own public key infrastructure (PKI) that is used exclusively for
+Puppet has its own public key infrastructure (:term:`PKI`) that is used exclusively for
 the puppet application. The PKI is used to provide access control and protect
-communications between the puppet master and the clients.
+communications between the :term:`Puppet Server` and the clients.
 
 Additional information on Puppet and PKI can be found at `<https://docs.puppet.com/background/ssl/certificates_pki.html>`_.
 
-SIMP installs a cron job that will download a copy of the certificate revocation
-list(CRL) two times per day.  If there is a client certificate that needs to be
-revoked, they can be added to the CRL and will no longer be able to connect to
-the puppet master.
+SIMP installs a scheduled job that will download a copy of the certificate
+revocation list (:term:`CRL`) two times per day.  If there is a client
+certificate that needs to be revoked, they can be added to the CRL and will no
+longer be able to connect to the Puppet Server.
 
 References: :ref:`SC-17`

--- a/docs/security_mapping/components/pupmod/transmission_confidentiality_and_integrity/control.rst
+++ b/docs/security_mapping/components/pupmod/transmission_confidentiality_and_integrity/control.rst
@@ -1,8 +1,8 @@
 Transmission Confidentiality and Integrity
 ------------------------------------------
 
-The SIMP server/puppet master uses TLS for communications between the puppet
+The :term:`Puppet Server` uses :term:`TLS` for communications between the puppet
 master and clients.  The protocols  for that communications are limited to
-TLSv1, TLSv1.1, and TLSv1.2.
+TLSv1.2.
 
 References: :ref:`SC-8`

--- a/docs/user_guide/Certificates/Certificates.inc
+++ b/docs/user_guide/Certificates/Certificates.inc
@@ -23,7 +23,7 @@ differently.
 :code:`simp_options::pki` can have one of three settings:
 
 #. ``simp`` -  Keypairs are distributed from a central location on the Puppet
-   master to the :file:`/etc/pki/simp/x509` directory on the client. Any
+   server to the :file:`/etc/pki/simp/x509` directory on the client. Any
    applications using them will then make a copy in
    :file:`/etc/pki/simp_apps/<app name>/x509` with the correct permissions for
    an application to use.

--- a/docs/user_guide/Certificates/Official_Certificates.inc
+++ b/docs/user_guide/Certificates/Official_Certificates.inc
@@ -2,11 +2,11 @@ Installing Official Certificates
 --------------------------------
 
 This section describes how to install infrastructure certificates from an
-official certificate authority on the Puppet master for distribution to client
+official certificate authority on the :term:`SIMP Server` for distribution to client
 servers.  You need to have :code:`simp_options::pki` set to ``simp`` on the
 client for this to work.
 
-The key distribution directory on the Puppet master is the
+The key distribution directory on the SIMP Server is the
 :file:`site_files/pki_files/files/keydist` sub-directory located under the
 :term:`SIMP Secondary Environment`,
 :file:`/var/simp/environments/{environment}`.
@@ -34,7 +34,7 @@ Here is an example key distribution directory for a ``production``
    /var/simp/environments/production/site_files/pki_files/files/keydist/yourcomputer.your.domain/yourcomputer.your.domain.pem
    /var/simp/environments/production/site_files/pki_files/files/keydist/yourcomputer.your.domain/yourcomputer.your.domain.pub
 
-To install official certificates on the Puppet master, do the following:
+To install official certificates on the SIMP Server, do the following:
 
 #. Copy the certificates received from a proper :term:`CA` to the SIMP server.
 #. Add the certificates for the node to the key distribution directory in

--- a/docs/user_guide/Client_Management.rst
+++ b/docs/user_guide/Client_Management.rst
@@ -79,7 +79,7 @@ can use an existing DNS infrastructure.
    :file:`named/var/named/forward/<your.domain>.db` and
    :file:`named/var/named/reverse/<your reverse domain>.db` files at any time;
    just remember to run :command:`puppet agent -t --tags named` on the Puppet
-   master to propagate the updates.
+   server to propagate the updates.
 
 
 Configure DHCP

--- a/docs/user_guide/Client_Management.rst
+++ b/docs/user_guide/Client_Management.rst
@@ -22,10 +22,10 @@ Client systems should meet the following minimum requirements:
 -  HDD: 22 GB
 
 
-Configuring the Puppet Master
+Configuring the Puppet Server
 -----------------------------
 
-Perform the following actions as ``root`` on the Puppet master system **prior**
+Perform the following actions as ``root`` on the :term:`Puppet Server` **prior**
 to attempting to install a client.
 
 
@@ -66,12 +66,12 @@ can use an existing DNS infrastructure.
      :file:`named/var/named/reverse/0.0.10.db` and then rename these files
      to appropriately match your environment.
 
-#. Run :command:`puppet agent -t --tags named` on the Puppet master to apply
+#. Run :command:`puppet agent -t --tags named` on the Puppet Server to apply
    the changes.
 #. Validate DNS and ensure the :file:`/etc/resolv.conf` is updated appropriately.
 #. If an :file:`rndc.key` error appears when starting :program:`named`, see the
    `BIND Documentation`_.  Once you have resolved the issue, re-run
-   :command:`puppet agent -t` on the Puppet master to apply.
+   :command:`puppet agent -t` on the Puppet Server to apply.
 
 .. NOTE::
 
@@ -96,7 +96,7 @@ Configure DHCP
 
    MAC addresses in the following section need to be lower case letters.
 
-Perform the following actions as ``root`` on the Puppet master system
+Perform the following actions as ``root`` on the Puppet Server system
 prior to attempting to install a client.
 
 Open :file:`/var/simp/environments/production/rsync/<OSTYPE>/Global/dhcpd/dhcpd.conf`
@@ -124,7 +124,7 @@ and edit it to suit the necessary environment. Make sure the following is done:
 
 Save and close the file.
 
-Run :command:`puppet agent -t` on the Puppet master to apply the changes.
+Run :command:`puppet agent -t` on the Puppet Server to apply the changes.
 
 .. _PXE_Boot:
 
@@ -203,7 +203,7 @@ master, try the following options:
   serious issues with certificates.
 * Remove :file:`/etc/puppetlabs/puppet/ssl` on the client system; run
   :command:`puppetserver ca clean --certname <CLIENT.FQDN>` on the
-  Puppet master and try again.
+  Puppet Server and try again.
 
 If you are getting permission errors, make sure the SELinux context is correct
 on all files, as well as the owner and group permissions.

--- a/docs/user_guide/Initial_Server_Configuration.rst
+++ b/docs/user_guide/Initial_Server_Configuration.rst
@@ -91,7 +91,7 @@ Configuring the SIMP Server
       all configuration options are correct.
 
       You can debug issues by either looking at the log files in ``/root/.simp`` or by running
-      ``puppet agent -t --masterport=8150``.
+      ``puppet agent -t --serverport=8150``.
 
 #. Run ``reboot`` to restart your system and apply the necessary kernel
    configuration items.

--- a/docs/user_guide/PXE_Boot.inc
+++ b/docs/user_guide/PXE_Boot.inc
@@ -189,7 +189,7 @@ Verify the static files are in the correct location:
 Dynamic Linux Model Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create a :term:`site profile` module for the TFTP server on the Puppet master
+Create a :term:`site profile` module for the TFTP server on the :term:`Puppet Server`
 to set up the various files to model different systems.
 
 #. Create the file :file:`tftpboot.pp` in your :term:`site profile`.
@@ -215,10 +215,12 @@ to set up the various files to model different systems.
      kickstart file needed.
 
      .. NOTE::
+
         If using the default cfg files, know that they do not have the
         :file:`_el{[6,7]}` tags at the end of their names.
 
      .. NOTE::
+
         The :code:`simp_disk_crypt` option shown below switches on transparent
         disk encryption as described in the :ref:`ig-disk-encryption`
         documentation and is recommended if you have a requirement for disk
@@ -313,9 +315,10 @@ to set up the various files to model different systems.
 
 
 #. After updating the above file, type :command:`puppet agent -t --tags tftpboot` on
-   the Puppet master.
+   the Puppet Server.
 
    .. NOTE::
+
       To provide PXE boot configuration for more OSs, create, in the
       :file:`tftpboot.pp` file, a :code:`tftpboot::linux_model` or
       :code:`tftpboot::linux_model_efi` block for each OS type. Then, assign

--- a/docs/user_guide/SIMP_Administration/Classification_and_Data/Assigning_Classes_to_Nodes.inc
+++ b/docs/user_guide/SIMP_Administration/Classification_and_Data/Assigning_Classes_to_Nodes.inc
@@ -7,8 +7,7 @@ section. The lists of included classed are controlled by the ``simp::classes``
 and ``simp::server::classes`` class parameters:
 
 * The ``simp::classes`` parameter is available for all nodes.
-* The ``simp::server::classes`` parameter is available only for the SIMP server
-  (Puppet master).
+* The ``simp::server::classes`` parameter is available only for the :term:`SIMP Server`.
 
 To preserve various levels of ordering and overrides, it is highly recommended
 that you use the ``simp::classes`` and ``simp::server::classes`` class parameters

--- a/docs/user_guide/SIMP_Administration/Classification_and_Data/SIMP_Scenarios.inc
+++ b/docs/user_guide/SIMP_Administration/Classification_and_Data/SIMP_Scenarios.inc
@@ -37,7 +37,7 @@ refer to this module.
 
 .. NOTE::
 
-   The SIMP or Puppet master is exempt from most of these settings, and will be
+   The :term:`SIMP Server` is exempt from most of these settings, and will be
    using most features from the *simp* scenario by default. The SIMP server
    should only have services on it related to Puppet and systems management,
    and SIMP modules all work with all security features enabled. See the

--- a/docs/user_guide/SIMP_Administration/Environments/Deployment_Scenarios.inc
+++ b/docs/user_guide/SIMP_Administration/Environments/Deployment_Scenarios.inc
@@ -76,7 +76,7 @@ environment's ``modules/`` directory.
 
 This scenario requires the least preparation: it doesn't require a control
 repository, a remote git-hosting service, or even a functioning network.  It
-also works automatically on any monolithic SIMP master (6.4.0+) that was
+also works automatically on any monolithic SIMP server (6.4.0+) that was
 installed from ISO or RPM.  In fact, the initial run of ``simp config`` uses
 this method to deploy the system's first modules into the production
 environment.
@@ -93,14 +93,15 @@ It requires:
 * The ``simp`` command
 * A pre-existing Puppet environment directory (``simp environment new``)
 * A simp Puppetfile (``simp puppetfile generate``)
-* No additional compile masters.
+* No additional compile servers.
 
 .. IMPORTANT::
+
    The local deployment scenario is only suitable for a single monolithic SIMP
-   master.
+   server.
 
 .. NOTE::
-   If you need to scale beyond a single master, you should :ref:`deploy
+   If you need to scale beyond a single server, you should :ref:`deploy
    from a control repository <ug-sa-env-deployment-scenarios--controlrepo>`.
 
 
@@ -145,7 +146,7 @@ to be).  A good starting point is to review the article,
 The Control repository deployment scenario is recommended for:
 
 * Environments that manage their infrastructure as code
-* Infrastructures that need to scale beyond a single master (e.g., compile masters)
+* Infrastructures that need to scale beyond a single server (e.g., compile servers)
 * Administrators who are comfortable with git and Puppet control repositories
 * Puppet Enterprise users
 
@@ -156,7 +157,7 @@ It requires:
 * :term:`r10k` and/or :term:`Code Manager`, configured to deploy from the Control Repository
 * Keeping all remote Puppet module repositories (and the control repository's
   ``Puppetfile``) up-to-date as SIMP RPMs deliver new module versions to the
-  master's local filesystem
+  server's local filesystem
 
 Depending on the variation, it may also require:
 
@@ -232,9 +233,9 @@ Under this scenario, Puppet admins:
 When a control repository branch is updated, it automatically
 triggers an environment deployment on the Puppet Server:
 
-  * The Git-hosting service uses a webhook to notify the PE master/MoM about
+  * The Git-hosting service uses a webhook to notify the PE server/MoM about
     the branch that was changed
   * The webhook on the Puppet Server triggers PE Code Manager to deploy the branch
     as a staged environment
   * The PE File Sync service distributes the staged environment to any compile
-    masters, and promotes the code from staging to live use.
+    servers, and promotes the code from staging to live use.

--- a/docs/user_guide/SIMP_Administration/Environments/Deployment_Scenarios.inc
+++ b/docs/user_guide/SIMP_Administration/Environments/Deployment_Scenarios.inc
@@ -160,9 +160,9 @@ It requires:
 
 Depending on the variation, it may also require:
 
-* (optional) a local webhook on the Puppet master, configured to trigger the code deploy
+* (optional) a local webhook on the :term:`Puppet Server`, configured to trigger the code deploy
 * (optional) a webhook on the git-hosting service to trigger environment
-  deployments on the Puppet master after a control repository branch is updated
+  deployments on the Puppet Server after a control repository branch is updated
 
 .. IMPORTANT::
 
@@ -187,7 +187,7 @@ Under this scenario:
 * Puppet admins maintain a Puppet control repository (and Puppet module
   repositories) in an external git-hosting service.
 
-* An r10k user logs into the Puppet master and manually deploys entire
+* An r10k user logs into the Puppet Server and manually deploys entire
   :term:`Puppet environment` directories (one per branch) from the command
   line:
 
@@ -209,11 +209,11 @@ Under this scenario, Puppet admins:
 * Deploy a Puppet environment by pushing updates to a control repository branch
 
 When a control repository branch is updated, it automatically
-triggers an environment deployment on the Puppet master:
+triggers an environment deployment on the Puppet Server:
 
-  * The Git-hosting service uses a webhook to notify the Puppet master about
+  * The Git-hosting service uses a webhook to notify the Puppet Server about
     the branch that was changed
-  * The webhook on the Puppet master triggers r10k to deploy the branch as an
+  * The webhook on the Puppet Server triggers r10k to deploy the branch as an
     environment
 
 .. _ug-sa-env-deployment-scenarios--cr+pe-codemanager--variant:
@@ -230,11 +230,11 @@ Under this scenario, Puppet admins:
 * Deploy a Puppet environment by pushing updates to a control repository branch
 
 When a control repository branch is updated, it automatically
-triggers an environment deployment on the Puppet master:
+triggers an environment deployment on the Puppet Server:
 
   * The Git-hosting service uses a webhook to notify the PE master/MoM about
     the branch that was changed
-  * The webhook on the Puppet master triggers PE Code Manager to deploy the branch
+  * The webhook on the Puppet Server triggers PE Code Manager to deploy the branch
     as a staged environment
   * The PE File Sync service distributes the staged environment to any compile
     masters, and promotes the code from staging to live use.

--- a/docs/user_guide/SIMP_Administration/Environments/Environments_Examples.inc
+++ b/docs/user_guide/SIMP_Administration/Environments/Environments_Examples.inc
@@ -45,11 +45,11 @@ of your site specific modules in your environment.
 
 #. **Update SIMP Local Git Repositories**
 
-   On the yum server (usually the SIMP master on smaller deployments)
+   On the yum server (usually the SIMP server on smaller deployments)
    add any new or updated SIMP module RPMs to the yum repositories using
    your sites procedures.
 
-   On your SIMP master, clear the yum cache
+   On your SIMP server, clear the yum cache
 
    .. code-block:: sh
 
@@ -64,7 +64,7 @@ of your site specific modules in your environment.
       # or a simp Puppet module with a patch
       yum update pupmod-simp-aide
 
-   This will update the local git repositories on the SIMP master.
+   This will update the local git repositories on the SIMP server.
 
 #. **Deploy the Environment**
 

--- a/docs/user_guide/SIMP_Administration/Environments/SIMP_Environments.inc
+++ b/docs/user_guide/SIMP_Administration/Environments/SIMP_Environments.inc
@@ -127,8 +127,8 @@ Building on the environments above, it is useful to consider the following
 Secondary and Writable environment directories pose a problem for
 Puppet scaling:
 
-* Load-balanced compile masters *must* keep the contents of *both* secondary and
-  writable environment directories in sync across all compile masters.
+* Load-balanced compile servers *must* keep the contents of *both* secondary and
+  writable environment directories in sync across all compile servers.
 * Alternatively, disciplined use of Hiera Eyaml encryption must be used to
   replace all parameters that default to using Writable-environment functions
   like `simplib::passgen()`_.

--- a/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
@@ -12,7 +12,7 @@ Puppet Certificates
 ^^^^^^^^^^^^^^^^^^^
 
 Puppet certificates are issued and maintained strictly within Puppet.  Communication
-between the master and agents is granted and secured with HTTPS, which
+between the server and agents is granted and secured with HTTPS, which
 requires valid identifying SSL certificates. The :term:`Puppet Server` acts as the certificate
 authority for managing these certificates.
 

--- a/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/Certificate_Management.inc
@@ -13,11 +13,11 @@ Puppet Certificates
 
 Puppet certificates are issued and maintained strictly within Puppet.  Communication
 between the master and agents is granted and secured with HTTPS, which
-requires valid identifying SSL certificates. The Puppet master acts as the certificate
+requires valid identifying SSL certificates. The :term:`Puppet Server` acts as the certificate
 authority for managing these certificates.
 
 The client will automatically send a certificate request to the server if it cannot find
-a valid certificate. The Puppet master will automatically sign a certificate request if
+a valid certificate. The Puppet Server will automatically sign a certificate request if
 the client's name is in the  ``autosign.conf`` file, otherwise an administrator must sign
 the request using the ``puppetserver ca`` tool.
 

--- a/docs/user_guide/SIMP_Administration/General_Administration/Nightly_Updates.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/Nightly_Updates.inc
@@ -45,7 +45,7 @@ The Operating System Repos
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default location for the :term:`Operating System` (OS) repositories, on the
-Puppet master, is ``/var/www/yum/<OSTYPE>/<MAJORRELEASE>/x86_64``.
+:term:`SIMP Server`, is ``/var/www/yum/<OSTYPE>/<MAJORRELEASE>/x86_64``.
 
 An ``Updates`` repository has been configured in this space. All OS updates
 should be placed within this directory.

--- a/docs/user_guide/SIMP_Administration/General_Administration/The_SIMP_Utility.inc
+++ b/docs/user_guide/SIMP_Administration/General_Administration/The_SIMP_Utility.inc
@@ -14,10 +14,9 @@ simp passgen
 
 Throughout the SIMP codebase, you may find references to the ``simplib::passgen()``
 function. This function auto-generates passwords and stores them in
-the Puppet master in a sub-directory in the :term:`SIMP Writable Environment`:
+the :term:`SIMP Server` in a sub-directory in the :term:`SIMP Writable Environment`:
 
 ``/opt/puppetlabs/server/data/puppetserver/simp/environments/<environment>/simp_autofiles/gen_passwd``
-
 
 For more information, see the `simplib::passgen()`_ documentation.
 

--- a/docs/user_guide/Troubleshooting/Puppet_Certificate_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Certificate_Issues.rst
@@ -54,7 +54,7 @@ Puppet Server Certificate Issues
 --------------------------------
 
 To fix the issue where the Puppet Server certificate was removed using
-``puppet cert clean``, run ``puppet cert generate <your puppetserver's cert name>``
+``puppetserver ca clean``, run ``puppetserver ca generate <your puppetserver's cert name>``
 and restart the puppetserver service.
 
 

--- a/docs/user_guide/Troubleshooting/Puppet_Certificate_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Certificate_Issues.rst
@@ -8,7 +8,7 @@ Puppet Client Certificate Issues
 
 Most of the time, clients will have certificate issues due to the system clock
 not being properly set. Before taking any other measures, make sure that your
-system clock is correct on both the master and the clients!
+system clock is correct on both the server and the clients!
 
 If you need to fix client certificate issues outside of time, first make sure
 that you do not have a certificate already in place on your :term:`Puppet Server`.
@@ -26,7 +26,7 @@ the same name, remove that client's certificate from the system.
 
 .. WARNING::
 
-   If you delete the Puppet master's certificate, you will need to re-deploy
+   If you delete the Puppet Server's certificate, you will need to re-deploy
    Puppet certificates to **all** of your nodes!
 
 .. _rereg-puppet-client-certs:
@@ -43,14 +43,14 @@ simply run the following on your client once the server is ready.
    # puppet agent -t
 
 After running the puppet agent, sign off the new certificate request on the
-Puppet master.
+:term:`Puppet Server`.
 
 .. code-block:: bash
 
    # puppetserver ca list
    # puppetserver ca sign --certname <cert req name>
 
-Puppet Master Certificate Issues
+Puppet Server Certificate Issues
 --------------------------------
 
 To fix the issue where the Puppet Server certificate was removed using
@@ -58,7 +58,7 @@ To fix the issue where the Puppet Server certificate was removed using
 and restart the puppetserver service.
 
 
-If the ``/etc/puppetlabs/puppet/ssl`` directory was removed on the Puppet master
+If the ``/etc/puppetlabs/puppet/ssl`` directory was removed on the Puppet Server
 (and you do not have a backup of it) or for some other reason you need
 to regenerate all the Puppet certificates and the Puppet CA do the following:
 
@@ -69,24 +69,19 @@ to regenerate all the Puppet certificates and the Puppet CA do the following:
 
 #. Stop the ``puppetserver`` and ``puppetdb`` services.
 
-#. Remove the certificates and the CA on the Puppet master and generate the new
-   Puppet master and CA certificates.
+#. Remove the certificates and the CA on the Puppet Server and generate the new
+   Puppet Server and CA certificates.
 
    .. code-block:: bash
 
-      # puppet resource service puppet ensure=stopped
-      # puppet resource service puppetserver ensure=stopped
-      # rm -rf /etc/puppetlabs/puppet/ssl
-      # puppet master --no-daemonize --verbose
+      puppet resource service puppet ensure=stopped
+      puppet resource service puppetserver ensure=stopped
+      puppet resource service puppetdb ensure=stopped
 
-      # When you see "Notice: Starting Puppet master <VERSION>", type CTRL + C
+      puppet resource file /etc/puppetlabs/puppet/ssl ensure=absent force=true recurse=true
+      puppet apply -e '#noop'
 
-      # puppet resource service puppetserver ensure=running
-      # puppet resource service puppet ensure=running
-
-      # Confirm it is working again
-      # puppet agent -t
-
+      puppet resource service puppetserver ensure=running
 
 #. Remove the old certificates from each of the Puppet clients and re-register
    the client using the :ref:`rereg-puppet-client-certs` instructions.
@@ -96,10 +91,20 @@ to regenerate all the Puppet certificates and the Puppet CA do the following:
 
    .. code-block:: bash
 
-      # rm -rf /etc/puppetlabs/puppetdb/ssl/*
-      # puppetdb ssl-setup
+      puppet resource file /etc/puppetlabs/puppetdb/ssl ensure=absent force=true recurse=true
+      puppetdb ssl-setup
 
-#. Restart the ``puppetserver`` and ``puppetdb`` services
+#. Restart the ``puppetdb`` service
+
+   .. code-block:: bash
+
+      puppet resource service puppetdb ensure=running
+
+#. Confirm that everything is working
+
+   .. code-block:: bash
+
+      puppet agent -t
 
 Puppetserver and PuppetDB certificate mismatch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_guide/Troubleshooting/Puppet_Issues.rst
+++ b/docs/user_guide/Troubleshooting/Puppet_Issues.rst
@@ -30,7 +30,7 @@ other choice, resulting in unavoidable error messages.
 
 ``[master] ca`` is marked as deprecated from Puppet 5.5.6 onward.  This results
 in a harmless—but unavoidable—deprecation warning whenever ``puppet`` is run
-on Puppet masters configured to `not` act as the Puppet CA
+on Puppet Servers configured to `not` act as the Puppet CA
 (``pupmod::master::enable_ca: false``):
 ::
 

--- a/docs/user_guide/Upgrade_SIMP/General_Upgrade_Instructions.rst
+++ b/docs/user_guide/Upgrade_SIMP/General_Upgrade_Instructions.rst
@@ -98,9 +98,9 @@ steps as ``root``:
    * For RPM-based installation, follow your site's procedures to update your
      repositories.
 
-#. Install the RPMs on your SIMP master:
+#. Install the RPMs on your SIMP server:
 
-   After updating the repositories log onto the SIMP master  and su to root to
+   After updating the repositories log onto the SIMP server and :program:`su` to :code:`root` to
    perform the rest of the upgrade.
 
    .. code-block:: sh
@@ -113,7 +113,7 @@ steps as ``root``:
       # Make sure yum picks up the new RPMs
       yum clean all; yum makecache
 
-      # Apply updates to the local master
+      # Apply updates to the local server
       yum update -y
 
    For SIMP 6.4 and later, this will also update the system-local, SIMP-managed

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.0.0_6.1.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.0.0_6.1.0.inc
@@ -15,8 +15,8 @@ Upgrade Script
 ^^^^^^^^^^^^^^
 
 There were several issues found during the SIMP 6.0.0 to 6.1.0 upgrade that
-necessitated the creation of an upgrade script that is to be run on your SIMP
-Puppet masters.
+necessitated the creation of an upgrade script that is to be run on your
+:term:`SIMP Server` systems.
 
 .. NOTE::
 
@@ -66,7 +66,7 @@ The legacy :file:`auth.conf`, :file:`/etc/puppetlabs/puppet/auth.conf`, has
 been deprecated. :package:`pupmod-simp-pupmod` will back up the legacy
 :file:`auth.conf` after the upgrade.
 
-The Puppet master's :file:`auth.conf` is now managed by Puppet. You will need
+The Puppet Server's :file:`auth.conf` is now managed by Puppet. You will need
 to reproduce any custom work done to legacy :file:`auth.conf` via the new
 :code:`puppet_authorization::rule` define.  The stock rules are managed in
 :code:`pupmod::master::simp_auth`.

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
@@ -26,10 +26,10 @@ necessary during the upgrade.
      upgrading from 6.1.0, unless precautions are taken (detailed below).
 
    * SIMP installations that are upgraded using :term:`r10k` and :term:`Code
-     Manager` are unlikely to be affected, unless the SIMP master's
+     Manager` are unlikely to be affected, unless the SIMP server's
      :package:`puppet-agent` package is updated independently.
 
-   * These instructions only apply to the SIMP master—no changes are required on
+   * These instructions only apply to the SIMP server—no changes are required on
      clients.
 
 #. Before upgrading anything, add the following line to :file:`/etc/yum.conf`:
@@ -57,7 +57,7 @@ necessary during the upgrade.
       # Make sure yum picks up the new RPMs
       yum clean all; yum makecache
 
-      # Apply updates to the local master
+      # Apply updates to the local server
       yum update -y
 
 #. After running :command:`yum update`, remove the :code:`exclude=puppet-agent`

--- a/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
+++ b/docs/user_guide/Upgrade_SIMP/Version_Maps/6.1.0_6.2.0.inc
@@ -148,7 +148,7 @@ Two major changes were made:
 
    In addition to solving these specific problems, the new bootstrap scripts
    use a configurable backoff algorithm in order prevent flooding a
-   heavily-loaded Puppet master with requests. See the
+   heavily-loaded :term:`Puppet Server` with requests. See the
    :code:`simp::server::kickstart::simp_client_bootstrap` class for details.
 
 

--- a/docs/user_guide/User_Management/Local_Users.rst
+++ b/docs/user_guide/User_Management/Local_Users.rst
@@ -104,7 +104,7 @@ Service Account
      $_svc_account_homedir = "/var/local/${_svc_account_user}"
 
      # Since this is a service account, automatically generate an SSH key for
-     # the user and store it on the Puppet master for distribution.
+     # the user and store it on the Puppet Server for distribution.
      $_svc_account_ssh_private_key = ssh_autokey($_svc_account_user, '2048', true)
      $_svc_account_ssh_public_key  = ssh_autokey($_svc_account_user, '2048')
 


### PR DESCRIPTION
- Correct SSL recovery documentation
- Convert all instances of 'puppet master' to 'puppet server'
- Correct a few links

[SIMP-10203] #close

[SIMP-10203]: https://simp-project.atlassian.net/browse/SIMP-10203