### PR TITLE
(SIMP-MAINT) Revert serverport to master

### DIFF
--- a/docs/FAQ/Puppet.rst
+++ b/docs/FAQ/Puppet.rst
@@ -27,7 +27,7 @@ troubleshoot the issue.
    .. code-block:: bash
 
       openssl s_client -host $(puppet config print server) \
-      -port $(puppet config print serverport) \
+      -port $(puppet config print masterport) \
       -cert $(puppet config print hostcert) \
       -key $(puppet config print hostprivkey) \
       -CAfile $(puppet config print localcacert)

--- a/docs/user_guide/Initial_Server_Configuration.rst
+++ b/docs/user_guide/Initial_Server_Configuration.rst
@@ -11,28 +11,28 @@ configuration of the :term:`SIMP server` straightforward and repeatable.
 In these instructions, we will be using the ``config`` and ``bootstrap``
 options of the ``simp`` command
 
-For a list of the commands ``simp`` provides, type ``simp help``. Type
-``simp <Command> --help`` for more information on a specific command.
+For a list of the commands ``simp`` provides, type :command:`simp help`. Type
+:command:`simp <Command> --help` for more information on a specific command.
 
-* ``simp config`` sets up configuration required to bootstrap the SIMP server
+* :command:`simp config` sets up configuration required to bootstrap the SIMP server
   with Puppet.  It asks questions, generates configuration files, and applies
   preliminary server configuration based on the answers.  It records the options
-  chosen in a file, ``/root/.simp/simp_conf.yaml`` and generates a log file
-  under ``/root/.simp/``.
+  chosen in a file, :file:`/root/.simp/simp_conf.yaml` and generates a log file
+  under :file:`/root/.simp/`.
 
   * You can use the ``--dry-run`` option to step through the questions without
-    changing anything and then run ``simp config  -a /root/.simp/simp_conf.yaml``
+    changing anything and then run :command:`simp config  -a /root/.simp/simp_conf.yaml`
     to apply the changes.
 
-  * ``simp config`` uses the ``production`` :term:`Puppet Environment` by
+  * :command:`simp config` uses the ``production`` :term:`Puppet Environment` by
     default. If you want to use a different initial environment, see
     :ref:`howto-use-an-alternate-simp-config-environment`.
 
-* ``simp bootstrap`` uses several targeted Puppet runs to configure the rest
-  of the system and generates a log file under ``/root/.simp/``.
+* :command:`simp bootstrap` uses several targeted Puppet runs to configure the rest
+  of the system and generates a log file under :file:`/root/.simp/`.
 
-For more details about initial configuration provided by ``simp config`` see
-:ref:`gsg-advanced-configuration`.
+For more details about initial configuration provided by :command:`simp
+config`, see :ref:`gsg-advanced-configuration`.
 
 Configuring the SIMP Server
 ---------------------------
@@ -48,13 +48,13 @@ Configuring the SIMP Server
    * **If you installed from the ISO**
 
      * Log in as ``simp``.
-     * Run  ``sudo su - root``.
+     * Run  :command:`sudo su - root`.
 
    * **If you installed from RPM**
 
      * Create a local user that can escalate to ``root`` and use it to access the ``root`` account.
 
-#. Run ``simp config`` and configure the system as prompted.
+#. Run :command:`simp config` and configure the system as prompted.
 
    * These settings will be used to set up files appropriate for bootstrapping the system.
 
@@ -62,7 +62,7 @@ Configuring the SIMP Server
 
        * Press *Enter* to keep the recommended value or enter your desired value.
 
-  * For more details about ``simp config``'s installation variables and actions, see
+  * For more details about :command:`simp config`'s installation variables and actions, see
     :ref:`gsg-advanced-configuration`.
 
   .. NOTE::
@@ -80,9 +80,9 @@ Configuring the SIMP Server
 
    For example, to extend the timeout to 10 minutes:
 
-   .. code:: bash
+   .. code:: console
 
-      $ simp bootstrap -w 10
+      simp bootstrap -w 10
 
    .. NOTE::
 

--- a/docs/user_guide/Initial_Server_Configuration.rst
+++ b/docs/user_guide/Initial_Server_Configuration.rst
@@ -72,7 +72,7 @@ Configuring the SIMP Server
 
 .. _ug-initial_server_configuration-run_bootstrap:
 
-3. Run ``simp bootstrap``.
+3. Run :command:`simp bootstrap`.
 
    If your SIMP server is on a virtual machine, or slow system, the default timeout for the
    Puppet server to start (5 minutes) may be too short.  You will want to extend this time by using
@@ -90,16 +90,16 @@ Configuring the SIMP Server
       occurred due to an error in SIMP configuration. Refer to the previous step and make sure that
       all configuration options are correct.
 
-      You can debug issues by either looking at the log files in ``/root/.simp`` or by running
-      ``puppet agent -t --serverport=8150``.
+      You can debug issues by either looking at the log files in :file:`/root/.simp` or by running
+      :command:`puppet agent -t --masterport=8150 --agent_disabled_lockfile /opt/puppetlabs/server/data/puppetserver/state/bootstrap.lock`.
 
-#. Run ``reboot`` to restart your system and apply the necessary kernel
+#. Run :command:`reboot` to restart your system and apply the necessary kernel
    configuration items.
 
 After rebooting, SIMP-managed security settings have been applied and the SIMP server is ready for
 site-specific configuration.
 
-To ``su`` to ``root`` from the  ``simp`` user, you must now use ``sudo su - root``.
+To ``su`` to ``root`` from the  ``simp`` user, you must now use :command:`sudo su - root`.
 
 Next Steps
 ----------


### PR DESCRIPTION
This patch reverts references to `serverport` back to `masterport` and updates some double-backticks with ReST roles.