### PR TITLE
Modernize build tooling, CI, and Read the Docs configuration

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -1,0 +1,60 @@
+# Run test matrix on Pull Requests
+#
+# ==============================================================================
+#
+# These jobs replace the checks that ran under GitLab CI before it was
+# dropped: the Python unit tests for the Sphinx conf helpers and a full
+# HTML build of the documentation, plus the standard SIMP RELENG checks.
+#
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+#
+
+name: PR Tests
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  releng-checks:
+    name: 'RELENG checks'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 4.0'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 4.0.6
+          bundler-cache: true
+      - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
+      - name: 'Tags and changelogs'
+        # NOTE: `pkg:compare_latest_tag` is intentionally not run here.  This
+        # repo's version comes from simp-core's simp.spec (via `munge:prep`),
+        # so that check can only pass when simp-core has bumped its version,
+        # not on every PR.
+        run: |
+          bundle exec rake pkg:check_version
+          bundle exec rake pkg:create_tag_changelog
+
+  python-tests:
+    name: 'Python unit tests'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+      - run: pip install -r requirements.txt pytest
+      - run: pytest -x --capture=no docs/conflib/get_simp_version_test.py
+
+  build-html-docs:
+    name: 'Build HTML docs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - run: sphinx-build -n -b html -d sphinx_cache docs html

--- a/.github/workflows/release_rpms.yml
+++ b/.github/workflows/release_rpms.yml
@@ -3,7 +3,7 @@
 #
 #             NOTICE: **This file is maintained with puppetsync**
 #
-# This file is updated automatically as part of a puppet module baseline.
+# This file is updated automatically as part of a standardized asset baseline.
 #
 # The next baseline sync will overwrite any local changes to this file!
 #
@@ -51,10 +51,14 @@ on:
         description: "Create release if missing? (tag must exist)"
         required: false
         default: 'yes'
-      build_container_os:
-        description: "Build container OS"
-        required: true
-        default: 'centos8'
+      build_container_oses:
+        description: "Build container OSes (JSON list)"
+        required: false
+        default: '["el8","el9","el10"]'
+      build_container_tag:
+        description: "Build container tag"
+        required: false
+        default: 'latest'
       target_repo:
         description: "Target repo (instead of this one)"
         required: false
@@ -86,13 +90,20 @@ env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag }}
 
 jobs:
-  create-and-attach-rpms-to-github-release:
+  # Per-release work (resolve or create the release, optionally wipe its
+  # assets) runs ONCE; the per-OS builds fan out from it below.
+  # See simp/puppetsync#84
+  resolve-release:
     name: >
-      Build and attach RPMs to Release:
+      Resolve GitHub Release:
       ${{ (github.event.inputs.target_repo != null && format('{0}/{1}', github.repository_owner, github.event.inputs.target_repo)) || github.repository }}
       ${{ github.event.inputs.release_tag }}
-      (build os: ${{ github.event.inputs.build_container_os }})
     runs-on: ubuntu-24.04
+    outputs:
+      release_id: ${{ steps.release-api.outputs.id }}
+      build_semver: ${{ steps.validate-inputs.outputs.build_semver }}
+      prebuild_suffix: ${{ steps.validate-inputs.outputs.prebuild_suffix }}
+      prebuild_number: ${{ steps.validate-inputs.outputs.prebuild_number }}
     steps:
       - name: "Validate inputs"
         id: validate-inputs
@@ -104,13 +115,13 @@ jobs:
 
           if [[ "$RELEASE_TAG" =~ ^(simp-|v)?([0-9]+\.[0-9]+\.[0-9]+)(-(rc|RC|[Aa]lpha|[Bb]eta|pre|post)?([0-9]+)?)?$ ]]; then
             if [ -n "${BASH_REMATCH[5]}" ]; then
-              echo "{prebuild_number}={${BASH_REMATCH[5]#-}}" >> $GITHUB_OUTPUT
+              echo "prebuild_number=${BASH_REMATCH[5]#-}" >> $GITHUB_OUTPUT
             fi
             if [ -n "${BASH_REMATCH[3]}" ]; then
-              echo "{prebuild_suffix}={${BASH_REMATCH[3]#-}}" >> $GITHUB_OUTPUT
+              echo "prebuild_suffix=${BASH_REMATCH[3]#-}" >> $GITHUB_OUTPUT
             fi
             if [ -n "${BASH_REMATCH[2]}" ]; then
-              echo "{build_semver}={${BASH_REMATCH[2]}}" >> $GITHUB_OUTPUT
+              echo "build_semver=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
             fi
           else
             printf '::error ::Release Tag format is not SemVer, X.Y.Z-R, X.Y.Z-<prerelease>: "%s"\n' "$RELEASE_TAG"
@@ -120,7 +131,6 @@ jobs:
       - name: >
           Query info for ${{ env.TARGET_REPO }}
           release ${{ github.event.inputs.release_tag }} ${{ steps.validate-inputs.outputs.prebuild_suffix }}
-          build os ${{ github.event.inputs.build_container_os }}
           (autocreate_release = '${{ github.event.inputs.autocreate_release }}')
         id: release-api
         env:
@@ -193,6 +203,37 @@ jobs:
               err => { throw err }
             )
 
+      - name: "Wipe all previous assets from GitHub Release (when clean == 'yes')"
+        if: ${{ github.event.inputs.clean == 'yes' && github.event.inputs.dry_run != 'yes' }}
+        uses: actions/github-script@v9
+        env:
+          release_id:  ${{ steps.release-api.outputs.id }}
+        with:
+          github-token: ${{ github.event.inputs.target_repo_token || secrets.GITHUB_TOKEN }}
+          script: |
+            const release_id = process.env.release_id
+            const [owner, repo] = process.env.TARGET_REPO.split('/')
+            const existingAssets = await github.rest.repos.listReleaseAssets({ owner, repo, release_id })
+
+            console.log( `  !! !! Wiping ALL uploaded assets for ${owner}/${repo} release (id: ${release_id})`)
+            existingAssets.data.forEach(async function(asset){
+              asset_id = asset.id
+              console.log( `  !! !! !! Wiping existing asset for ${asset.name} (id: ${asset_id})`)
+              await github.rest.repos.deleteReleaseAsset({ owner, repo, asset_id })
+            })
+
+  create-and-attach-rpms-to-github-release:
+    name: >
+      Build and attach RPMs to Release:
+      ${{ (github.event.inputs.target_repo != null && format('{0}/{1}', github.repository_owner, github.event.inputs.target_repo)) || github.repository }}
+      ${{ github.event.inputs.release_tag }}
+      (build os: ${{ matrix.os }})
+    needs: [ resolve-release ]
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        os: ${{ fromJSON(github.event.inputs.build_container_oses) }}
+    steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
@@ -202,11 +243,11 @@ jobs:
           fetch-depth: 0
 
       - name: 'Customize RPM Release tag via build/rpm_metadata/release (pre-release only)'
-        if: steps.validate-inputs.outputs.prebuild_suffix
+        if: needs.resolve-release.outputs.prebuild_suffix
         env:
-          BUILD_SEMVER: ${{ steps.validate-inputs.outputs.build_semver }}
-          PREBUILD_TAG: ${{ steps.validate-inputs.outputs.prebuild_suffix }}
-          PREBUILD_NUMBER: ${{ steps.validate-inputs.outputs.prebuild_number }}
+          BUILD_SEMVER: ${{ needs.resolve-release.outputs.build_semver }}
+          PREBUILD_TAG: ${{ needs.resolve-release.outputs.prebuild_suffix }}
+          PREBUILD_NUMBER: ${{ needs.resolve-release.outputs.prebuild_number }}
         # Note: To accomodate the capabilities of EL7's version of RPM, the
         # release number is formatted according to the Fedora Packaging
         # Guidelines' "Traditional versioning" conventions:
@@ -229,7 +270,7 @@ jobs:
       - name: 'Customize RPM Release tag via build/rpm_metadata/release (RPM rebuild)'
         if: ${{ github.event.inputs.rebuild_number != '' }}
         env:
-          BUILD_SEMVER: ${{ steps.validate-inputs.outputs.build_semver }}
+          BUILD_SEMVER: ${{ needs.resolve-release.outputs.build_semver }}
           REBUILD_NUMBER: ${{ github.event.inputs.rebuild_number }}
         run: |
           mkdir -p build/rpm_metadata
@@ -245,7 +286,7 @@ jobs:
       - name: >
           Build & Sign RPMs for
           ${{ github.event.inputs.release_tag }}
-          Release (${{ github.event.inputs.build_container_os }})
+          Release (${{ matrix.os }})
         uses: simp/github-action-build-and-sign-pkg-single-rpm@v2
         id: build-and-sign-rpm
         with:
@@ -253,28 +294,9 @@ jobs:
           gpg_signing_key_id: ${{ secrets.SIMP_DEV_GPG_SIGNING_KEY_ID }}
           gpg_signing_key_passphrase: ${{ secrets.SIMP_DEV_GPG_SIGNING_KEY_PASSPHRASE }}
           simp_core_ref_for_building_rpms: ${{ secrets.SIMP_CORE_REF_FOR_BUILDING_RPMS }}
-          simp_builder_docker_image: 'docker.io/simpproject/simp_build_${{ github.event.inputs.build_container_os }}:latest'
+          simp_builder_docker_image: 'ghcr.io/simp/simp-${{ matrix.os }}-build:${{ github.event.inputs.build_container_tag }}'
           path_to_build: "${{ (github.event.inputs.path_to_build != null && format('{0}/{1}', github.workspace, github.event.inputs.path_to_build)) || github.workspace }}"
           verbose: 'no'  #${{ github.event.inputs.verbose }}
-
-      - name: "Wipe all previous assets from GitHub Release (when clean == 'yes')"
-        if: ${{ github.event.inputs.clean == 'yes' && github.event.inputs.dry_run != 'yes' }}
-        uses: actions/github-script@v9
-        env:
-          release_id:  ${{ steps.release-api.outputs.id }}
-        with:
-          github-token: ${{ github.event.inputs.target_repo_token || secrets.GITHUB_TOKEN }}
-          script: |
-            const release_id = process.env.release_id
-            const [owner, repo] = process.env.TARGET_REPO.split('/')
-            const existingAssets = await github.rest.repos.listReleaseAssets({ owner, repo, release_id })
-
-            console.log( `  !! !! Wiping ALL uploaded assets for ${owner}/${repo} release (id: ${release_id})`)
-            existingAssets.data.forEach(async function(asset){
-              asset_id = asset.id
-              console.log( `  !! !! !! Wiping existing asset for ${asset.name} (id: ${asset_id})`)
-              await github.rest.repos.deleteReleaseAsset({ owner, repo, asset_id })
-            })
 
       - name: "Upload RPM file(s) to GitHub Release (dry_run != 'yes')"
         if: ${{ github.event.inputs.dry_run != 'yes' }}
@@ -282,7 +304,7 @@ jobs:
         env:
           rpm_file_paths: ${{ steps.build-and-sign-rpm.outputs.rpm_file_paths }}
           rpm_gpg_file: ${{ steps.build-and-sign-rpm.outputs.rpm_gpg_file }}
-          release_id:  ${{ steps.release-api.outputs.id }}
+          release_id:  ${{ needs.resolve-release.outputs.release_id }}
           clobber: ${{ github.event.inputs.clobber }}
           clean: ${{ github.event.inputs.clean }}
           dry_run: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/tag_deploy_github-rpms.yml
+++ b/.github/workflows/tag_deploy_github-rpms.yml
@@ -38,11 +38,32 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
+  releng-checks:
+    name: "RELENG checks"
+    if: github.repository_owner == 'simp'
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Assert '${{ github.ref }}' is a tag"
+        run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+      - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
+      - run: bundle exec rake pkg:check_version
+      - run: bundle exec rake pkg:compare_latest_tag
+      - run: bundle exec rake pkg:create_tag_changelog
+
   create-github-release:
     name: Deploy GitHub Release
+    needs: [ releng-checks ]
     if: github.repository_owner == 'simp'
     runs-on: ubuntu-latest
     outputs:
@@ -92,10 +113,11 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_PRERELASE: ${{ steps.tag-check.outputs.prerelease }}
         run: |
           echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
           args=(-F /tmp/.commit-msg.txt)
-          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
+          [[ $IS_PRERELASE == yes ]] && args+=(--prerelease)
 
           gh release create ${args[@]} "$TARGET_TAG"
 
@@ -106,13 +128,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TARGET_REPO: ${{ github.repository }}
-    strategy:
-      matrix:
-        os:
-          - centos7
-          - centos8
     steps:
-      - name: Trigger RPM release workflow (${{ matrix.os }})
+      # The build-OS matrix lives in release_rpms.yml (one dispatch builds
+      # every supported EL version) -- see simp/puppetsync#84
+      - name: Trigger RPM release workflow
         uses: actions/github-script@v9
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -120,7 +139,7 @@ jobs:
         with:
           github-token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE }}
           script: |
-            console.log( `== Building tag: '${ process.env.TARGET_TAG }' for os '${{ matrix.os}}'` )
+            console.log( `== Building tag: '${ process.env.TARGET_TAG }'` )
             const [owner, repo] = process.env.TARGET_REPO.split('/')
             await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: owner,
@@ -130,9 +149,8 @@ jobs:
               inputs: {
                 release_tag: process.env.TARGET_TAG,
                 clean: 'no',
-                clobber: 'yes',
-                build_container_os: '${{ matrix.os }}'
+                clobber: 'yes'
               }
             }).then((result) => {
-              console.log( `== Submitted workflow dispatch to build RPMs from ${{ matrix.os }}: status ${result.status}` )
+              console.log( `== Submitted workflow dispatch to build RPMs: status ${result.status}` )
             })

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,12 +7,14 @@ version: 2
 
 formats: all
 
-# The Docker image used for building the docs
-# NOTE: Check the v2 config docs for the available python versions in each image
 build:
-  image: latest
+  os: ubuntu-24.04
+  tools:
+    python: '3.13'
+
+sphinx:
+  configuration: docs/conf.py
 
 python:
-  version: 3.7
   install:
     - requirements: requirements.txt

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,30 @@
-# Variables:
-#
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-# PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>4']
-gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+gem_sources = ENV.fetch('GEM_SERVERS', 'https://rubygems.org').split(%r{[, ]+})
 
 gem_sources.each { |gem_source| source gem_source }
 
-gem 'rake'
-# renovate: datasource=rubygems versioning=ruby
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.24.0')
-gem 'pry'
-gem 'net-telnet', ['< 0.2.0']
+group :test do
+  # The Rakefile uses OpenStruct; ostruct is a bundled gem as of Ruby 3.5
+  gem 'ostruct'
+  gem 'rake'
+  # renovate: datasource=rubygems versioning=ruby
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
+end
+
+group :development do
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'pry-doc'
+end
+
+# Evaluate extra gemfiles if they exist
+extra_gemfiles = [
+  ENV.fetch('EXTRA_GEMFILE', ''),
+  "#{__FILE__}.project",
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding) # rubocop:disable Security/Eval
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ ENV['SIMP_INTERNAL_pkg_ignore'] = 'build/rpm_metadata'
 require 'ostruct'
 require 'rake/clean'
 require 'simp/rake'
+require 'tempfile'
 require 'yaml'
 require 'find'
 
@@ -90,7 +91,7 @@ EOM
       require 'open-uri'
       begin
         warn("Downloading '#{spec_url}'")
-        open(spec_url) do |specfile|
+        URI.open(spec_url) do |specfile|
           tmpspec.write(specfile.read)
         end
       rescue OpenURI::HTTPError => e

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML
 rst2pdf
 sphinx-csv-filter>=0.3.0
 sphinx-rtd-theme
-# Need this to fix bullets
-# https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-docutils==0.23
+# Sphinx and sphinx-rtd-theme both cap the docutils version they support
+# (sphinx-rtd-theme 3.x requires docutils < 0.22), so let pip resolve a
+# compatible version instead of pinning one that conflicts.
+docutils<0.22


### PR DESCRIPTION
This repo hadn't had attention in a while. This PR brings its tooling in line with the rest of the SIMP org (matching the recent simp-adapter modernization) and fixes several things that were silently broken.

### Ruby build tooling (Ruby 4.0 / OpenVox)
- Move to `simp-rake-helpers ~> 6.0` (replaces `puppetlabs_spec_helper` with `voxpupuli-test`, pulls in `openvox` instead of `puppet`)
- Rewrite the Gemfile in the current baseline style; drop the unused `PUPPET_VERSION` default (`~>4`) and the obsolete `net-telnet` pin; add `ostruct` (bundled gem as of Ruby 3.5) and the standard `Gemfile.project`/`Gemfile.local`/`EXTRA_GEMFILE` hooks
- Fix `munge:prep` for Ruby ≥ 3.0: `Kernel#open` no longer opens URLs, so the simp.spec download now uses `URI.open`

Verified on Ruby 4.0.5: `bundle install`, `rake -T`, `rake munge:prep` (including the GitHub simp.spec download path), `pkg:check_version`, and `pkg:create_tag_changelog`.

### requirements.txt was uninstallable
Renovate bumped `docutils` to an exact `==0.23` pin, but every available Sphinx release requires `docutils < 0.23` (and sphinx-rtd-theme 3.x requires `< 0.22`), so `pip install -r requirements.txt` fails with `ResolutionImpossible`. Nobody noticed because the GitLab CI that built the docs was dropped. Replaced with `docutils < 0.22`; pip now resolves Sphinx 9.1.0 / docutils 0.21.2 / sphinx-rtd-theme 3.1.0, and the HTML build succeeds (verified locally with Python 3.14).

### GitHub Actions
- Sync `release_rpms.yml` and `tag_deploy_github-rpms.yml` verbatim from the current puppetsync asset baseline: EL8/EL9/EL10 build matrix from a single dispatch (was centos7/centos8), ghcr.io build containers (the docker.io simpproject images are retired), `PUPPET_VERSION: '~> 8'`, RELENG checks at tag time, and the `$GITHUB_OUTPUT` syntax fix
- Add `pr_tests.yml`, restoring the checks lost with GitLab CI: the conflib Python unit tests, a full `sphinx-build -n -b html` build, and the RELENG checks (`pkg:check_version`, `pkg:create_tag_changelog`) on Ruby 4.0. `pkg:compare_latest_tag` is deliberately not run on PRs — this repo's version comes from simp-core's simp.spec, so it can only pass once simp-core bumps; it still runs at tag time.

### Read the Docs
The old `.readthedocs.yaml` used `build.image: latest` + `python.version: 3.7`, which RTD no longer accepts. Updated to `build.os: ubuntu-24.04` with Python 3.13 and an explicit `sphinx.configuration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)