### PR TITLE
Remove rubygem-simp-build-helpers from gem release procedures

### DIFF
--- a/docs/contributors_guide/maintenance/Ruby_Gem_Release_Procedures.rst
+++ b/docs/contributors_guide/maintenance/Ruby_Gem_Release_Procedures.rst
@@ -5,7 +5,6 @@ This section will describe the release procedures for the SIMP Ruby gems
 used to build and test SIMP components. The relevant components include
 
 * ``rubygem-simp-beaker-helpers``
-* ``rubygem-simp-build-helpers``
 * ``rubygem-simp-rake-helpers``
 * ``rubygem-simp-rspec-puppet-facts``
 


### PR DESCRIPTION
See simp/rubygem-simp-rake-helpers#274 and simp/rubygem-simp-build-helpers#10.

`Simp::Build::ReleaseMapper` has been absorbed into simp-rake-helpers 6.1.0, and `rubygem-simp-build-helpers` is now deprecated and ready to archive — so it is no longer a gem that gets released, and shouldn't be listed among the gems covered by these procedures.

One-line removal from the component list in `Ruby_Gem_Release_Procedures.rst`.